### PR TITLE
Runtime exception fix

### DIFF
--- a/src/org/newrelic/nrjmx/JMXFetcher.java
+++ b/src/org/newrelic/nrjmx/JMXFetcher.java
@@ -19,6 +19,7 @@ import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import javax.management.RuntimeMBeanException;
+import javax.management.RuntimeOperationsException;
 import javax.management.openmbean.CompositeData;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
@@ -100,7 +101,7 @@ public class JMXFetcher {
             
             try {
                 value = connection.getAttribute(objectName, attrName);
-            } catch (AttributeNotFoundException | InstanceNotFoundException | MBeanException | ReflectionException | IOException | RuntimeMBeanException e) {
+            } catch (AttributeNotFoundException | InstanceNotFoundException | MBeanException | ReflectionException | IOException | RuntimeMBeanException | RuntimeOperationsException e) {
                 logger.warning("Can't get attribute " + attrName + " for bean " + objectName.toString());
                 continue;
             }

--- a/src/org/newrelic/nrjmx/JMXFetcher.java
+++ b/src/org/newrelic/nrjmx/JMXFetcher.java
@@ -18,6 +18,7 @@ import javax.management.MalformedObjectNameException;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
+import javax.management.RuntimeMBeanException;
 import javax.management.openmbean.CompositeData;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
@@ -99,7 +100,7 @@ public class JMXFetcher {
             
             try {
                 value = connection.getAttribute(objectName, attrName);
-            } catch (AttributeNotFoundException | InstanceNotFoundException | MBeanException | ReflectionException | IOException e) {
+            } catch (AttributeNotFoundException | InstanceNotFoundException | MBeanException | ReflectionException | IOException | RuntimeMBeanException e) {
                 logger.warning("Can't get attribute " + attrName + " for bean " + objectName.toString());
                 continue;
             }


### PR DESCRIPTION
There are two uncaught exceptions that the nrjmx tool is not currently catching that were causing cryptic failures in the newrelic-integrations-sdk jmx library. One was RuntimeMbeanException, the other RuntimeOperationsException, both caused by trying to collect unavailable attributes.

This pull request adds those exceptions to the list being caught and ignored so that collection can continue. 

Alternative: Another option instead of merging this is to catch all exceptions and continue. This provides the benefit that future unforseen exceptions will still be caught and collections for integrations will not fail with difficult-to-debug messages. 