### PR TITLE
Catch all exceptions

### DIFF
--- a/src/org/newrelic/nrjmx/JMXFetcher.java
+++ b/src/org/newrelic/nrjmx/JMXFetcher.java
@@ -101,8 +101,8 @@ public class JMXFetcher {
             
             try {
                 value = connection.getAttribute(objectName, attrName);
-            } catch (AttributeNotFoundException | InstanceNotFoundException | MBeanException | ReflectionException | IOException | RuntimeMBeanException | RuntimeOperationsException e) {
-                logger.warning("Can't get attribute " + attrName + " for bean " + objectName.toString());
+            } catch (Exception e) {
+                logger.warning("Can't get attribute " + attrName + " for bean " + objectName.toString() + ": " +  e.getMessage());
                 continue;
             }
 


### PR DESCRIPTION
Previously, this problem had been mitigated by adding exceptions encountered to the list of caught exceptions. However, this did not account for future exceptions that might be thrown. This commit changes it so that all exceptions will be caught and logged without causing a runtime exception. 