### PR TITLE
Provide improvements to shell script wrapper. 

### DIFF
--- a/bin/nrjmx
+++ b/bin/nrjmx
@@ -1,6 +1,29 @@
-#!/usr/bin/env sh
-if [ -f /usr/lib/nrjmx/nrjmx.jar ]; then
-    java -jar /usr/lib/nrjmx/nrjmx.jar $@
-else
-    java -jar `dirname $0`/nrjmx.jar $@
+#!/usr/bin/env bash
+
+set -u
+set -o pipefail
+
+JAR="/usr/lib/nrjmx/nrjmx.jar"
+if [[ ! -s "${JAR}" ]];then
+    # Gets the directory where the script is located. Works on mac or linux
+    SCRIPTDIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P)"
+    JAR="${SCRIPTDIR}/nrjmx.jar"
 fi
+
+if [[ ! -s "${JAR}" ]];then
+    echo "ERROR - jar ${JAR} does not exist" > /dev/stderr
+    exit 1
+fi
+
+JAVA="${JAVA_HOME:-}/bin/java"
+if [[ ! -s "${JAVA}" ]];then
+    JAVA=$(which java 2> /dev/null)
+fi
+
+if [[ ! -s "${JAVA}" ]];then
+    echo "ERROR - unable to find java binary on PATH or in JAVA_HOME/bin" > /dev/stderr
+    exit 1
+fi
+
+"${JAVA}" -jar "${JAR}" $@
+

--- a/nrjmx.iml
+++ b/nrjmx.iml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: org.yaml:snakeyaml:1.13" level="project" />
+    <orderEntry type="library" name="Maven: commons-cli:commons-cli:1.4" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.0" level="project" />
+  </component>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>nrjmx</groupId>
   <artifactId>nrjmx</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.3</version>
   <name>nrjmx</name>
   <description>The New Relic JMX tool provides a command line tool to connect to a JMX server and retrieve the MBeans it exposes.</description>
   <organization>


### PR DESCRIPTION
The improvements are centered on error handling. As an operator, I want
the script:

- to find the java binary from JAVA_HOME by default and
then from the path. If it finds the jar in neither place, then output a
useful error message
- exit with a non-zero code if there are unitialized bash variables
- exit with a non-zero code and useful error message if the jar cannot
be found