### PR TITLE
Add -url command line parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ could execute:
 $ echo
 "org.apache.cassandra.metrics:type=Table,keyspace=*,scope=*,name=ReadLatency" | java -jar target/nrjmx-0.0.1-SNAPSHOT-jar-with-dependencies.jar -hostname 127.0.0.1 -port 7199 -username user -password pwd
 ```
+
+## Updates
+### 1.0.5
+- Add `--url` command line parameter to allow the end-user to use atypical service urls. Defaults to `service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi` which is `service:jmx:rmi:///jndi/rmi://<hostname>:<port>/jmxrmi`
+  - Use caution when quoting the string!

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>nrjmx</groupId>
   <artifactId>nrjmx</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <name>nrjmx</name>
   <description>The New Relic JMX tool provides a command line tool to connect to a JMX server and retrieve the MBeans it exposes.</description>
   <organization>

--- a/src/org/newrelic/nrjmx/Application.java
+++ b/src/org/newrelic/nrjmx/Application.java
@@ -42,7 +42,7 @@ public class Application {
         JMXFetcher fetcher;
         try {
             fetcher = new JMXFetcher(
-                cliArgs.getHostname(), cliArgs.getPort(),
+                cliArgs.getHostname(), cliArgs.getPort(), cliArgs.getUrl(),
                 cliArgs.getUsername(), cliArgs.getPassword(),
                 cliArgs.getKeyStore(), cliArgs.getKeyStorePassword(),
                 cliArgs.getTrustStore(), cliArgs.getTrustStorePassword()

--- a/src/org/newrelic/nrjmx/Arguments.java
+++ b/src/org/newrelic/nrjmx/Arguments.java
@@ -12,6 +12,7 @@ public class Arguments {
     private String hostname;
     private int port;
     private String username;
+    private String url;
     private String password;
     private String keyStore;
     private String keyStorePassword;
@@ -23,6 +24,9 @@ public class Arguments {
 
     Arguments(String[] args) {
         Options options = new Options();
+        Option url = Option.builder("U")
+            .longOpt("url").desc("JMX url (service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi)").hasArg().build();
+        options.addOption(url);
         Option hostname = Option.builder("H")
             .longOpt("hostname").desc("JMX hostname (localhost)").hasArg().build();
         options.addOption(hostname);
@@ -77,6 +81,7 @@ public class Arguments {
         }
 
 
+        this.url = cmd.getOptionValue("url", "service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi");
         this.hostname = cmd.getOptionValue("hostname", "localhost");
         this.port     = Integer.parseInt(cmd.getOptionValue("port", "7199"));
         this.username = cmd.getOptionValue("username", "");
@@ -128,4 +133,12 @@ public class Arguments {
     public boolean debugMode() {
         return debug;
     }
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
 }

--- a/src/org/newrelic/nrjmx/JMXFetcher.java
+++ b/src/org/newrelic/nrjmx/JMXFetcher.java
@@ -41,8 +41,8 @@ public class JMXFetcher {
         public ValueError(String message) { super(message); }
     };
 
-    public JMXFetcher(String hostname, int port, String username, String password , String keyStore, String keyStorePassword, String trustStore, String trustStorePassword) throws ConnectionError {
-        String connectionString = String.format("service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi", hostname, port);
+    public JMXFetcher(String hostname, int port, String url, String username, String password , String keyStore, String keyStorePassword, String trustStore, String trustStorePassword) throws ConnectionError {
+        String connectionString = String.format(url, hostname, port);
         Map<String, String[]> env = new HashMap<>();
         if (username != "") {
           env.put(JMXConnector.CREDENTIALS, new String[] { username, password });


### PR DESCRIPTION
Allow end-user to modify the service URL with a -url command line parameter, defaults to service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi