### PR TITLE
URI path enhancements for ForgeRock OpenDJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,12 @@ Example of usage with remoting:
 ```bash
 $ ./bin/nrjmx -hostname 127.0.0.1 -port 7199 -username user -password pwd -remote
 ```
- 
+
+### Non-Standard JMX Service URI 
+
+If your JMX provider uses a non-standard JMX service URI, you can use the flag `-uriPath` to specify the path portion. For example, ForgeRock OpenDJ uses a JMX service URI like `service:jmx:rmi:///jndi/rmi://localhost:1689/org.opends.server.protocols.jmx.client-unknown`
+
+To extract data from this application:
+```bash
+$ ./bin/nrjmx -hostname localhost -port 1689 -uriPath "org.opends.server.protocols.jmx.client-unknown" -username user -password pwd
+```

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>nrjmx</groupId>
   <artifactId>nrjmx</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>nrjmx</name>
   <description>The New Relic JMX tool provides a command line tool to connect to a JMX server and retrieve the MBeans it exposes.</description>
   <organization>

--- a/src/main/java/org/newrelic/nrjmx/Application.java
+++ b/src/main/java/org/newrelic/nrjmx/Application.java
@@ -54,7 +54,7 @@ public class Application {
         JMXFetcher fetcher = null;
         try {
             fetcher = new JMXFetcher(
-                cliArgs.getHostname(), cliArgs.getPort(),
+                cliArgs.getHostname(), cliArgs.getPort(), cliArgs.getUriPath(),
                 cliArgs.getUsername(), cliArgs.getPassword(),
                 cliArgs.getKeyStore(), cliArgs.getKeyStorePassword(),
                 cliArgs.getTrustStore(), cliArgs.getTrustStorePassword(),

--- a/src/main/java/org/newrelic/nrjmx/Arguments.java
+++ b/src/main/java/org/newrelic/nrjmx/Arguments.java
@@ -5,6 +5,7 @@ import org.apache.commons.cli.*;
 class Arguments {
     private String hostname;
     private int port;
+    private String uriPath;
     private String username;
     private String password;
     private String keyStore;
@@ -30,6 +31,9 @@ class Arguments {
             Option port = Option.builder("P")
                 .longOpt("port").desc("JMX port (7199)").hasArg().build();
             options.addOption(port);
+            Option uriPath = Option.builder("U")
+                    .longOpt("uriPath").desc("path for the JMX service URI. Defaults to jmxrmi").hasArg().build();
+                options.addOption(uriPath);
             Option username = Option.builder("u")
                 .longOpt("username").desc("JMX username").hasArg().build();
             options.addOption(username);
@@ -73,6 +77,7 @@ class Arguments {
         Arguments argsObj = new Arguments();
         argsObj.hostname = cmd.getOptionValue("hostname", "localhost");
         argsObj.port = Integer.parseInt(cmd.getOptionValue("port", "7199"));
+        argsObj.uriPath  = cmd.getOptionValue("uriPath", "jmxrmi");
         argsObj.username = cmd.getOptionValue("username", "");
         argsObj.password = cmd.getOptionValue("password", "");
         argsObj.keyStore = cmd.getOptionValue("keyStore", "");
@@ -94,6 +99,10 @@ class Arguments {
         return port;
     }
 
+    String getUriPath() {
+    	return uriPath;
+    }
+    
     String getUsername() {
         return username;
     }

--- a/src/main/java/org/newrelic/nrjmx/JMXFetcher.java
+++ b/src/main/java/org/newrelic/nrjmx/JMXFetcher.java
@@ -1,14 +1,28 @@
 package org.newrelic.nrjmx;
 
-import javax.management.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import javax.management.Attribute;
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
-import java.io.IOException;
-import java.util.*;
-import java.util.logging.Logger;
 
 public class JMXFetcher {
     private static final Logger logger = Logger.getLogger("nrjmx");
@@ -34,8 +48,8 @@ public class JMXFetcher {
         }
     }
 
-    public JMXFetcher(String hostname, int port, String username, String password, String keyStore, String keyStorePassword, String trustStore, String trustStorePassword, boolean isRemote) throws ConnectionError {
-        String connectionString = String.format("service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi", hostname, port);
+    public JMXFetcher(String hostname, int port, String uriPath, String username, String password , String keyStore, String keyStorePassword, String trustStore, String trustStorePassword, boolean isRemote) throws ConnectionError {
+        String connectionString = String.format("service:jmx:rmi:///jndi/rmi://%s:%s/%s", hostname, port, uriPath);
         if (isRemote) {
             connectionString = String.format("service:jmx:remoting-jmx://%s:%s", hostname, port);
         }
@@ -104,6 +118,10 @@ public class JMXFetcher {
 
             try {
                 value = connection.getAttribute(objectName, attrName);
+                if (value instanceof javax.management.Attribute) {
+                	Attribute jmxAttr = (Attribute) value;
+                	value = jmxAttr.getValue();
+                }
             } catch (Exception e) {
                 logger.warning("Can't get attribute " + attrName + " for bean " + objectName.toString() + ": " + e.getMessage());
                 continue;


### PR DESCRIPTION
Add uriPath command line option support applications that use non-standard JMX service urls such as ForgeRock OpenDJ. 

OpenDJ uses a JMX service uri like: service:jmx:rmi:///jndi/rmi://localhost:1689/org.opends.server.protocols.jmx.client-unknown

The current version has a path of "jmxrmi" hard-coded so it is unable to connect to OpenDJ and other applications that do not use this value.

OpenDJ also returns a javax.management.Attribute when you call getAttribute instead of the attribute value. So I added a check for that as well.