### PR TITLE
Correct generated artifact name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.1 (2019-06-17)
+- (Linux-only) tar.gz packaging as an alternative to the current package managers
+
 ## 1.3.0 (2019-06-17)
 ## Added
 - Non standard (`jmxrmi`) URI path support via `-uriPath` argument.

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
                             <goal>copy</goal>
                         </goals>
                         <configuration>
-                            <sourceFile>target/${project.artifactId}-${project.version}-jar-with-dependencies.jar
+                            <sourceFile>target/${project.artifactId}-${project.version}.jar
                             </sourceFile>
                             <destinationFile>bin/nrjmx.jar</destinationFile>
                         </configuration>
@@ -136,7 +136,7 @@
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
                         <configuration>
-                            <finalName>nrjmx_${project.version}-1_amd64</finalName>
+                            <finalName>${project.artifactId}-${project.version}</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                             <descriptor>assembly.xml</descriptor>
                         </configuration>
@@ -177,16 +177,16 @@
                             <dataSet>
                                 <data>
                                     <type>file</type>
-                                    <src>target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</src>
+                                    <src>target/${project.artifactId}-${project.version}.jar</src>
                                     <dst>
-                                        /usr/lib/${project.artifactId}/${project.artifactId}-${project.version}-jar-with-dependencies.jar
+                                        /usr/lib/${project.artifactId}/${project.artifactId}-${project.version}.jar
                                     </dst>
                                 </data>
                                 <data>
                                     <type>link</type>
                                     <linkName>/usr/lib/${project.artifactId}/${project.artifactId}.jar</linkName>
                                     <linkTarget>
-                                        /usr/lib/${project.artifactId}/${project.artifactId}-${project.version}-jar-with-dependencies.jar
+                                        /usr/lib/${project.artifactId}/${project.artifactId}-${project.version}.jar
                                     </linkTarget>
                                     <symlink>true</symlink>
                                 </data>
@@ -248,12 +248,12 @@
                                     <sources>
                                         <source>
                                             <location>
-                                                target/${project.artifactId}-${project.version}-jar-with-dependencies.jar
+                                                target/${project.artifactId}-${project.version}.jar
                                             </location>
                                         </source>
                                         <softlinkSource>
                                             <location>
-                                                /usr/lib/${project.artifactId}/${project.artifactId}-${project.version}-jar-with-dependencies.jar
+                                                /usr/lib/${project.artifactId}/${project.artifactId}-${project.version}.jar
                                             </location>
                                             <destination>${project.artifactId}.jar</destination>
                                         </softlinkSource>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>nrjmx</groupId>
     <artifactId>nrjmx</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <name>nrjmx</name>
     <description>The New Relic JMX tool provides a command line tool to connect to a JMX server and retrieve the MBeans
         it exposes.

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
                             <goal>copy</goal>
                         </goals>
                         <configuration>
-                            <sourceFile>target/${project.artifactId}-${project.version}.jar
+                            <sourceFile>target/${project.artifactId}_linux_${project.version}_noarch.jar
                             </sourceFile>
                             <destinationFile>bin/nrjmx.jar</destinationFile>
                         </configuration>
@@ -136,7 +136,7 @@
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
                         <configuration>
-                            <finalName>${project.artifactId}-${project.version}</finalName>
+                            <finalName>${project.artifactId}_linux_${project.version}_noarch</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                             <descriptor>assembly.xml</descriptor>
                         </configuration>
@@ -177,16 +177,16 @@
                             <dataSet>
                                 <data>
                                     <type>file</type>
-                                    <src>target/${project.artifactId}-${project.version}.jar</src>
+                                    <src>target/${project.artifactId}_linux_${project.version}_noarch.jar</src>
                                     <dst>
-                                        /usr/lib/${project.artifactId}/${project.artifactId}-${project.version}.jar
+                                        /usr/lib/${project.artifactId}/${project.artifactId}_linux_${project.version}_noarch.jar
                                     </dst>
                                 </data>
                                 <data>
                                     <type>link</type>
                                     <linkName>/usr/lib/${project.artifactId}/${project.artifactId}.jar</linkName>
                                     <linkTarget>
-                                        /usr/lib/${project.artifactId}/${project.artifactId}-${project.version}.jar
+                                        /usr/lib/${project.artifactId}/${project.artifactId}_linux_${project.version}_noarch.jar
                                     </linkTarget>
                                     <symlink>true</symlink>
                                 </data>
@@ -248,12 +248,12 @@
                                     <sources>
                                         <source>
                                             <location>
-                                                target/${project.artifactId}-${project.version}.jar
+                                                target/${project.artifactId}_linux_${project.version}_noarch.jar
                                             </location>
                                         </source>
                                         <softlinkSource>
                                             <location>
-                                                /usr/lib/${project.artifactId}/${project.artifactId}-${project.version}.jar
+                                                /usr/lib/${project.artifactId}/${project.artifactId}_linux_${project.version}_noarch.jar
                                             </location>
                                             <destination>${project.artifactId}.jar</destination>
                                         </softlinkSource>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.2.2</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/src/test/java/org/newrelic/jmx/JMXFetcherTest.java
+++ b/src/test/java/org/newrelic/jmx/JMXFetcherTest.java
@@ -3,10 +3,12 @@ package org.newrelic.jmx;
 import org.junit.Assert;
 import org.junit.Test;
 import org.newrelic.nrjmx.JMXFetcher;
+import org.newrelic.nrjmx.Logging;
 import org.testcontainers.containers.GenericContainer;
 
 import java.io.*;
 import java.util.Arrays;
+import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
 
@@ -73,6 +75,7 @@ public class JMXFetcherTest {
 
 
     public void testJMXFetching(JMXFetcher jmxFetcher) throws Exception {
+        Logging.setup(Logger.getLogger("nrjmx"), true);
         // Test preparation
         // builds a piped, readable output stream
         PipedOutputStream output = new PipedOutputStream();


### PR DESCRIPTION
## Description

### What are you changing/fixing?

The `*jar-with-dependencies.jar` file was not generated anymore but some scripts relied on this name, making packaging step to fail.

### Does your Pull Request introduce breaking changes?

No. It just fixes a broken behaviour.

### Do the users need to upgrade immediately to the new version?

No

### Do you introduce new dependencies on other libraries?

No.

## Checklist: before you submit

- [x] apply the labels that best suit the context of your Pull Request.
- [x] include unit or integration testing for your changes/additions.

