### PR TITLE
Build JMXFetcher from full connection URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Next
+
+- Build JMXFetcher from full connection URL
+- Set debug log entry on nice log lvl to be shown only for verbose mode
+- Clean up cmd execution log entries
+- Increase test timeout to build on slow boxes
+
 ## 1.4.1 (2019-10-01)
 - Fixed issue when parsing float NaN values.
 

--- a/src/test/java/org/newrelic/jmx/JMXFetcherTest.java
+++ b/src/test/java/org/newrelic/jmx/JMXFetcherTest.java
@@ -59,6 +59,19 @@ public class JMXFetcherTest {
         }
     }
 
+
+    @Test(timeout = 20_000)
+    public void testJMXFromConnectionURL() throws Exception {
+        GenericContainer container = jmxService();
+        try {
+            container.start();
+            testJMXFetching(new JMXFetcher("service:jmx:rmi:///jndi/rmi://localhost:7199/jmxrmi",
+                    "", "", "", "", "", ""));
+        } finally {
+            container.close();
+        }
+    }
+
     @Test(timeout = 20_000)
     public void testJMXWithSSL() throws Exception {
         GenericContainer container = jmxSSLService();


### PR DESCRIPTION
## Description

### What are you changing/fixing?

Build JMXFetcher from full connection URL, so user can avoid using the combination of arguments like host, port, is-remote and so. 

### Does your Pull Request introduce breaking changes?

No

### Do the users need to upgrade immediately to the new version?

No

### Do you introduce new dependencies on other libraries?

No

## Checklist: before you submit

- [x] apply the labels that best suit the context of your Pull Request.
- [x] include unit or integration testing for your changes/additions.

