### PR TITLE
fix: Updated jmxterm to v1.0.2 to fix vulnerability in jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.NEXT
 
+## 1.5.3
+
 - Removed `org.yaml` unused bundled dependency. This will reduce the
   size of the JAR file.
+- Upgraded `jmxterm` to v1.0.2 (fixes a vulnerability in bundled jar)
 
 ## 1.5.2 (2019-11-18)
 ## Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
                                     <goal>wget</goal>
                                 </goals>
                                 <configuration>
-                                    <url>https://github.com/jiaqi/jmxterm/releases/download/v1.0.1/jmxterm-1.0.1-uber.jar</url>
+                                    <url>https://github.com/jiaqi/jmxterm/releases/download/v1.0.2/jmxterm-1.0.2-uber.jar</url>
                                     <outputFileName>jmxterm.jar</outputFileName>
                                     <outputDirectory>bin</outputDirectory>
                                 </configuration>
@@ -348,5 +348,4 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
     </properties>
-
 </project>


### PR DESCRIPTION
## Description

Updating `jmxterm` to `v1.0.2` to fix vulnerability in jar
