### PR TITLE
feat: Updated to now publish a noarch linux package

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -43,7 +43,7 @@ jobs:
           java-version: '11'
           java-package: jdk
       - name: Build with Gradle
-        run: ./gradlew build --info --stacktrace
+        run: make build
 
   package-linux:
     name: Run Linux package task
@@ -67,7 +67,7 @@ jobs:
           java-version: '11'
           java-package: jdk
       - name: Package with Gradle
-        run: ./gradlew package --warn --stacktrace
+        run: make package/linux
       - name: Install debsigs
         run: sudo apt-get install -y debsigs
       - name: Sign packages

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -37,9 +37,9 @@ jobs:
           java-version: '11'
           java-package: jdk
       - name: Build with Gradle
-        run: ./gradlew build --info --stacktrace
+        run: make build
       - name: Package with Gradle
-        run: ./gradlew package --warn --stacktrace
+        run: make package
       - name: Install debsigs
         run: sudo apt-get install -y debsigs
       - name: Sign packages

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ hs_err_pid*
 # Gradle
 .gradle
 build/
+
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+JAVA_VERSION 	?= jdk-11.0.9_11.1
+DOCKER_BIN 		?= docker
+DOCKER_CMD 		?= $(DOCKER_BIN) run --rm -it -v ${HOME}/.gradle:/root/.gradle -v $(CURDIR):/src/nrjmx -w /src/nrjmx adoptopenjdk/openjdk11:$(JAVA_VERSION)-centos
+
+.PHONY : package
+package:
+	@($(DOCKER_CMD) ./gradlew clean package --warn --stacktrace)

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,44 @@ JAVA_VERSION 	?= jdk-11.0.9_11.1
 DOCKER_BIN 		?= docker
 DOCKER_CMD 		?= $(DOCKER_BIN) run --rm -it -v ${HOME}/.gradle:/root/.gradle -v $(CURDIR):/src/nrjmx -w /src/nrjmx adoptopenjdk/openjdk11:$(JAVA_VERSION)-centos
 
+GRADLE_BIN		?= $(CURDIR)/gradlew
+GRADLE_FLAGS	+=  --warn
+GRADLE_FLAGS	+=  --stacktrace
+#GRADLE_FLAGS	+=  --warning-mode all
+
 .PHONY : package
 package :
-	@($(DOCKER_CMD) ./gradlew clean package --warn --stacktrace)
+	@($(GRADLE_BIN) clean package $(GRADLE_FLAGS))
 
 .PHONY : package/linux
 package/linux :
-	@($(DOCKER_CMD) ./gradlew clean package-linux --warn --stacktrace)
+	@($(GRADLE_BIN) clean package-linux $(GRADLE_FLAGS))
 
 .PHONY : package/windows
 package/windows :
-	@($(DOCKER_CMD) ./gradlew clean package-windows --warn --stacktrace)
+	@($(GRADLE_BIN) clean package-windows $(GRADLE_FLAGS))
+
+.PHONY : build
+build : GRADLE_FLAGS += --info
+build :
+	@($(GRADLE_BIN) clean build $(GRADLE_FLAGS))
+
+.PHONY : ci/build
+ci/build :
+	@($(DOCKER_CMD) make build)
+
+.PHONY : ci/package
+ci/package :
+	@($(DOCKER_CMD) make package)
+
+.PHONY : ci/package/linux
+ci/package/linux :
+	@($(DOCKER_CMD) make package/linux)
+
+.PHONY : ci/package/windows
+ci/package/windows :
+	@($(DOCKER_CMD) make package/windows)
+
+.PHONY : test
+test:
+	@($(GRADLE_BIN) clean test)

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,13 @@ DOCKER_BIN 		?= docker
 DOCKER_CMD 		?= $(DOCKER_BIN) run --rm -it -v ${HOME}/.gradle:/root/.gradle -v $(CURDIR):/src/nrjmx -w /src/nrjmx adoptopenjdk/openjdk11:$(JAVA_VERSION)-centos
 
 .PHONY : package
-package:
+package :
 	@($(DOCKER_CMD) ./gradlew clean package --warn --stacktrace)
+
+.PHONY : package/linux
+package/linux :
+	@($(DOCKER_CMD) ./gradlew clean package-linux --warn --stacktrace)
+
+.PHONY : package/windows
+package/windows :
+	@($(DOCKER_CMD) ./gradlew clean package-windows --warn --stacktrace)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 JAVA_VERSION 	?= jdk-11.0.9_11.1
 DOCKER_BIN 		?= docker
 DOCKER_CMD 		?= $(DOCKER_BIN) run --rm -it -v ${HOME}/.gradle:/root/.gradle -v $(CURDIR):/src/nrjmx -w /src/nrjmx adoptopenjdk/openjdk11:$(JAVA_VERSION)-centos

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,7 +129,8 @@ tasks.register<Zip>("jlinkDistZip") {
 tasks.register<Tar>("jlinkDistTar") {
     dependsOn(tasks.jlink, "downloadJmxTerm", "jmxtermScripts")
     destinationDirectory.set(file("${buildDir}/distributions"))
-    archiveFileName.set("${project.name}-${project.version}-jlink.tar.gz")
+    // nrjmx_linux_x.y.z_amd64.tar.gz
+    archiveFileName.set("${project.name}_linux_${project.version}_amd64.tar.gz")
     compression = Compression.GZIP
 
     from("LICENSE") {
@@ -233,17 +234,6 @@ tasks.distZip {
     }
 }
 
-tasks.distTar {
-    dependsOn("downloadJmxTerm", "jmxtermScripts")
-    archiveExtension.set("tar.gz")
-    compression = Compression.GZIP
-
-    from("${buildDir}/jmxterm") {
-        include("**")
-        into("${project.name}-${project.version}")
-    }
-}
-
 tasks.register("package") {
     group = "Distribution"
     description = "Builds all packages"
@@ -257,11 +247,8 @@ tasks.register("package-linux") {
     description = "Builds all packages for Linux"
     dependsOn(
             "noarchJar",
-            "distTar",
-            "distZip",
             "buildDeb",
             "buildRpm",
-            "jlinkDistZip",
             "jlinkDistTar")
 }
 
@@ -269,7 +256,5 @@ tasks.register("package-windows") {
     group = "Distribution"
     description = "Builds all packages for Windows"
     dependsOn(
-            "noarchJar",
-            "distZip",
             "jlinkDistZip")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,8 @@ tasks.register<Jar>("noarchJar") {
 tasks.register<Zip>("jlinkDistZip") {
     dependsOn(tasks.jlink, "downloadJmxTerm", "jmxtermScripts")
     destinationDirectory.set(file("${buildDir}/distributions"))
-    archiveFileName.set("${project.name}-${project.version}-jlink.zip")
+    // nrjmx_windows_x.y.z_amd64.zip
+    archiveFileName.set("${project.name}_windows_${project.version}_amd64.zip")
 
     into("${project.name}-${project.version}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=nrjmx
-version=1.6.1
+version=1.6.2
 description=The New Relic JMX tool provides a command line tool to connect to a JMX server and retrieve the MBeans it exposes
 jmxTermVersion=1.0.2

--- a/script/upload_linux_release.sh
+++ b/script/upload_linux_release.sh
@@ -13,17 +13,18 @@ INTEGRATION_PATH=$1
 TAG=$2
 SEMVER=`echo "${TAG}" | cut -c 2-`
 
-echo "===> Uploading ${INTEGRATION_PATH}_${SEMVER}-1_amd64.deb to ${TAG}"
-hub release edit -a "${INTEGRATION_PATH}_${SEMVER}-1_amd64.deb" -m "${TAG}" "${TAG}"
+DEB_FILE=${INTEGRATION_PATH}_${SEMVER}-1_amd64.deb
+echo "===> Uploading ${DEB_FILE} to ${TAG}"
+hub release edit -a "${DEB_FILE}" -m "${TAG}" "${TAG}"
 
-echo "===> Uploading ${INTEGRATION_PATH}-${SEMVER}-1.x86_64.rpm to ${TAG}"
-hub release edit -a "${INTEGRATION_PATH}-${SEMVER}-1.x86_64.rpm" -m "${TAG}" "${TAG}"
+RPM_FILE=${INTEGRATION_PATH}-${SEMVER}-1.x86_64.rpm
+echo "===> Uploading ${RPM_FILE} to ${TAG}"
+hub release edit -a "${RPM_FILE}" -m "${TAG}" "${TAG}"
 
-echo "===> Uploading ${INTEGRATION_PATH}-${SEMVER}-noarch.ja to ${TAG}"
-hub release edit -a "${INTEGRATION_PATH}-${SEMVER}-noarch.jar" -m "${TAG}" "${TAG}"
+NOARCH_JAR=${INTEGRATION_PATH}-${SEMVER}-noarch.jar
+echo "===> Uploading ${NOARCH_JAR} to ${TAG}"
+hub release edit -a "${NOARCH_JAR}" -m "${TAG}" "${TAG}"
 
-echo "===> Uploading ${INTEGRATION_PATH}-${SEMVER}.tar.gz to ${TAG}"
-hub release edit -a "${INTEGRATION_PATH}-${SEMVER}.tar.gz" -m "${TAG}" "${TAG}"
-
-echo "===> Uploading ${INTEGRATION_PATH}-${SEMVER}-jlink.tar.gz to ${TAG}"
-hub release edit -a "${INTEGRATION_PATH}-${SEMVER}-jlink.tar.gz" -m "${TAG}" "${TAG}"
+TAR_FILE=${INTEGRATION_PATH}_linux_${SEMVER}_amd64.tar.gz
+echo "===> Uploading ${TAR_FILE} to ${TAG}"
+hub release edit -a "${TAR_FILE}" -m "${TAG}" "${TAG}"

--- a/script/upload_zip_release.sh
+++ b/script/upload_zip_release.sh
@@ -13,5 +13,6 @@ INTEGRATION_PATH=$1
 TAG=$2
 SEMVER=`echo "${TAG}" | cut -c 2-`
 
-echo "===> Uploading ${INTEGRATION_PATH}-${SEMVER}-jlink.zip to ${TAG}"
-hub release edit -a "${INTEGRATION_PATH}-${SEMVER}-jlink.zip" -m "${TAG}" "${TAG}"
+ZIP_FILE=${INTEGRATION_PATH}_windows_${SEMVER}_amd64.zip
+echo "===> Uploading ${ZIP_FILE} to ${TAG}"
+hub release edit -a "${ZIP_FILE}" -m "${TAG}" "${TAG}"


### PR DESCRIPTION
## Description

Because we now provide a `jlink` version we removed the noarch version we published. This causes issues as the `jlink` version does not work on Alpine Linux (incompatible due to their use of [`musl`](https://bugs.openjdk.java.net/browse/JDK-8229469)). Releasing a `noarch` version will allow us to use it in Alpine containers.