### PR TITLE
fixed subprocess termination issue

### DIFF
--- a/bin/nrjmx
+++ b/bin/nrjmx
@@ -26,5 +26,5 @@ if [ ! -z "${NRIA_NRJMX_DEBUG}" ]; then
   JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y"
 fi
 
-${java_tool} ${JAVA_OPTS} -cp ${CLASSPATH} org.newrelic.nrjmx.Application $@
+exec ${java_tool} ${JAVA_OPTS} -cp ${CLASSPATH} org.newrelic.nrjmx.Application $@
 

--- a/gojmx/gojmx_test.go
+++ b/gojmx/gojmx_test.go
@@ -873,7 +873,7 @@ func TestProcessExits(t *testing.T) {
 
 		stderrBytes, err := io.ReadAll(&stderr)
 		assert.NoError(t, err)
-		// A message will appear o stderr depending on the OS when the process is killed.
+		// A message will appear on stderr, depending on the OS, when the process is killed.
 		assert.NotEmpty(t, string(stderrBytes))
 	}()
 
@@ -907,7 +907,7 @@ func findChildProcessByName(t *testing.T, parentProcess *gopsutil.Process, child
 	var err error
 	var children []*gopsutil.Process
 
-	require.Eventually(t, func() bool {
+	require.Eventuallyf(t, func() bool {
 		children, err = parentProcess.Children()
 		if err != nil {
 			return false
@@ -915,7 +915,7 @@ func findChildProcessByName(t *testing.T, parentProcess *gopsutil.Process, child
 
 		return len(children) > 0
 	}, 5*time.Second, 50*time.Millisecond,
-		"couldn't found the java subprocess")
+		"couldn't found the %s subprocess", childName)
 
 	// We check only the first child since we don't start multiple processes in parallel.
 	name, err := children[0].Name()

--- a/gojmx/internal/testutils/cmd/main.go
+++ b/gojmx/internal/testutils/cmd/main.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/newrelic/nrjmx/gojmx"
+	"os"
+	"strconv"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		panic("missing hostname and port")
+	}
+
+	hostname := os.Args[1]
+
+	port, err := strconv.ParseInt(os.Args[2], 10, 32)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+
+	config := &gojmx.JMXConfig{
+		Hostname:         hostname,
+		Port:             int32(port),
+		RequestTimeoutMs: 60000,
+	}
+
+	client, err := gojmx.NewClient(ctx).Open(config)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(client.GetClientVersion())
+
+	result, err := client.QueryMBeanAttributes("*:*")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(gojmx.FormatJMXAttributes(result))
+}

--- a/gojmx/internal/testutils/test_utils.go
+++ b/gojmx/internal/testutils/test_utils.go
@@ -6,7 +6,6 @@
 package testutils
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -17,9 +16,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 )
 
@@ -275,22 +273,6 @@ func DoHttpRequest(method, url string, body []byte) ([]byte, error) {
 	return ioutil.ReadAll(resp.Body)
 }
 
-// ReadFirstLine will return just the first line of the file.
-func ReadFirstLine(filename string) (string, error) {
-	file, err := os.Open(filename)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-	scanner := bufio.NewScanner(file)
-	scanner.Scan()
-	output := scanner.Text()
-	if err := scanner.Err(); err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(output), nil
-}
-
 // GetContainerMappedPort returns the hostname and the port for a given container.
 func GetContainerMappedPort(ctx context.Context, container testcontainers.Container, targetPort nat.Port) (host string, port nat.Port, err error) {
 
@@ -311,19 +293,6 @@ func GetContainerMappedPort(ctx context.Context, container testcontainers.Contai
 	return
 }
 
-// ReadPidFile will read a given file and extract the pid form it.
-func ReadPidFile(fileName string) (int32, error) {
-	line, err := ReadFirstLine(fileName)
-	if err != nil {
-		return -1, err
-	}
-	pid, err := strconv.Atoi(line)
-	if err != nil {
-		return -1, err
-	}
-	return int32(pid), nil
-}
-
 func isRunningInDockerContainer() bool {
 	// docker creates a .dockerenv file at the root
 	// of the directory tree inside the container.
@@ -335,4 +304,17 @@ func isRunningInDockerContainer() bool {
 	}
 
 	return false
+}
+
+// NrJMXAsSubprocess will return an exec.Cmd that will be configured to run the main function from testutils.
+func NrJMXAsSubprocess(ctx context.Context, host, port string) *exec.Cmd {
+	cmdPath := fmt.Sprintf("%s/gojmx/internal/testutils/cmd/main.go", PrjDir)
+
+	args := []string{
+		"run",
+		cmdPath,
+		host,
+		port,
+	}
+	return exec.CommandContext(ctx, "go", args...)
 }

--- a/gojmx/internal/testutils/test_utils.go
+++ b/gojmx/internal/testutils/test_utils.go
@@ -310,11 +310,7 @@ func isRunningInDockerContainer() bool {
 func NrJMXAsSubprocess(ctx context.Context, host, port string) *exec.Cmd {
 	cmdPath := fmt.Sprintf("%s/gojmx/internal/testutils/cmd/main.go", PrjDir)
 
-	args := []string{
-		"run",
-		cmdPath,
-		host,
-		port,
-	}
-	return exec.CommandContext(ctx, "go", args...)
+	return exec.CommandContext(ctx,
+		"go", "run", cmdPath, host, port,
+	)
 }

--- a/gojmx/process.go
+++ b/gojmx/process.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"time"
 )
 
@@ -52,7 +51,7 @@ func (p *process) start() (*process, error) {
 		return p, errProcessAlreadyRunning
 	}
 
-	p.cmd = exec.CommandContext(p.ctx, filepath.Clean(getNRJMXExec()), nrJMXV2Flag)
+	p.cmd = buildExecCommand(p.ctx)
 
 	var err error
 

--- a/gojmx/process_darwin.go
+++ b/gojmx/process_darwin.go
@@ -9,3 +9,8 @@ const (
 	// defaultNRJMXExec default nrjmx tool executable path.
 	defaultNRJMXExec = "/usr/local/bin/nrjmx"
 )
+
+// buildExecCommand adds os specifics to the command.
+func buildExecCommand(ctx context.Context) *exec.Cmd {
+	return exec.CommandContext(ctx, filepath.Clean(getNRJMXExec()), nrJMXV2Flag)
+}

--- a/gojmx/process_darwin.go
+++ b/gojmx/process_darwin.go
@@ -5,6 +5,12 @@
 
 package gojmx
 
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+)
+
 const (
 	// defaultNRJMXExec default nrjmx tool executable path.
 	defaultNRJMXExec = "/usr/local/bin/nrjmx"

--- a/gojmx/process_linux.go
+++ b/gojmx/process_linux.go
@@ -5,7 +5,26 @@
 
 package gojmx
 
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
 const (
 	// defaultNRJMXExec default nrjmx tool executable path.
 	defaultNRJMXExec = "/usr/bin/nrjmx"
 )
+
+// buildExecCommand adds os specifics to the command.
+func buildExecCommand(ctx context.Context) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, filepath.Clean(getNRJMXExec()), nrJMXV2Flag)
+
+	// Terminate the subprocess when parent dies.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
+
+	return cmd
+}

--- a/gojmx/process_windows.go
+++ b/gojmx/process_windows.go
@@ -9,3 +9,8 @@ const (
 	// defaultNRJMXExec default nrjmx tool executable path.
 	defaultNRJMXExec = "c:\\progra~1\\newrel~1\\nrjmx\\nrjmx.bat"
 )
+
+// buildExecCommand adds os specifics to the command.
+func buildExecCommand(ctx context.Context) *exec.Cmd {
+	return exec.CommandContext(ctx, filepath.Clean(getNRJMXExec()), nrJMXV2Flag)
+}

--- a/gojmx/process_windows.go
+++ b/gojmx/process_windows.go
@@ -5,6 +5,12 @@
 
 package gojmx
 
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+)
+
 const (
 	// defaultNRJMXExec default nrjmx tool executable path.
 	defaultNRJMXExec = "c:\\progra~1\\newrel~1\\nrjmx\\nrjmx.bat"


### PR DESCRIPTION
When nrjmx java application is processing data, if the agent terminates an integration process (because of a timeout for e.g.)
the java process will remain open until service group is stopped.

This PR will:
- improve the previous test we had in place for this scenario.
- fix the bash script wrapper for java command. (the java process will replace the bash process)
- adds `PR_SET_PDEATHSIG` for the java process, so when the parent is terminated, this will be also terminated.
