### PR TITLE
added custom mbean to test server

### DIFF
--- a/gojmx/gojmx_test.go
+++ b/gojmx/gojmx_test.go
@@ -865,14 +865,14 @@ func TestProcessExits(t *testing.T) {
 
 		close(waitToStart)
 	}()
-	
+
 	// For troubleshooting purposes.
 	defer func() {
 		stdoutBytes, _ := io.ReadAll(&stdout)
-		fmt.Println(stdoutBytes)
+		fmt.Println(fmt.Sprintf("[DEBUG] Stdout: '%s'", stdoutBytes))
 
 		stderrBytes, _ := io.ReadAll(&stderr)
-		fmt.Println(stderrBytes)
+		fmt.Println(fmt.Sprintf("[DEBUG] Stderr: '%s'", stderrBytes))
 	}()
 
 	<-waitToStart

--- a/test-server/README.md
+++ b/test-server/README.md
@@ -49,6 +49,12 @@ In the port `4567`:
 * `POST /cat`
     * BODY: `{"name":"Isidoro"}` would register in JMX a cat named Isidoro to the registry name
 
+
+* `POST /custom_cat`
+  * BODY: `{"name": "TombstoneScannedHistogram", "mBeanName":"org.apache.cassandra.metrics:type=Table,keyspace=test2,scope=test2,name=TombstoneScannedHistogram","floatValue":1.1,"doubleValue":3.2,"timeout": 60000}`
+  * would register in JMX a custom mBean named 'org.apache.cassandra.metrics:type=Table,keyspace=test2,scope=test2,name=TombstoneScannedHistogram'
+  * notice the 'timeout' attribute, it allows specifying a delay before the mBean will be returned by JMX endpoint.
+
 * `PUT /clear`
     * Will clear all the cats from JMX
 
@@ -68,5 +74,6 @@ $ ./nrjmx
 test:type=Cat,*
 {}
 ```
+## Troubleshooting
 
-    
+If registering mBeans fails, you can check the container logs for errors.

--- a/test-server/src/main/java/org/newrelic/jmx/CustomCat.java
+++ b/test-server/src/main/java/org/newrelic/jmx/CustomCat.java
@@ -1,0 +1,19 @@
+package org.newrelic.jmx;
+
+import javax.management.MBeanRegistration;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+public class CustomCat extends Cat {
+    private String mBeanName;
+
+    public CustomCat(String mBeanName, String name, Double doubleValue, Float floatValue, Boolean boolValue, Number numberValue, Integer timeout, long dateValue) {
+        super(name, doubleValue, floatValue, boolValue, numberValue, timeout, dateValue);
+        this.mBeanName = mBeanName;
+    }
+
+    @Override
+    public ObjectName preRegister(MBeanServer server, ObjectName name) throws Exception {
+        return new ObjectName(this.mBeanName);
+    }
+}

--- a/test-server/src/main/java/org/newrelic/jmx/Service.java
+++ b/test-server/src/main/java/org/newrelic/jmx/Service.java
@@ -50,6 +50,13 @@ public class Service {
             return "ok!\n";
         });
 
+        post("/custom_cat", (req, res) -> {
+            CustomCat cat = gson.fromJson(req.body(), CustomCat.class);
+            log.info("registering {}", cat);
+            server.registerMBean(cat, null);
+            return "ok!\n";
+        });
+
         final ObjectName queryObject = new ObjectName("*:type=Cat,*");
 
         // Removes all registered MBean cats


### PR DESCRIPTION
This PR adds custom mBean to test server.
Example of usage:
curl -X POST -d '{"name": "TombstoneScannedHistogram", "mBeanName":"org.apache.cassandra.metrics:type=Table,keyspace=test2,scope=test2,name=TombstoneScannedHistogram","floatValue":1.1,"doubleValue":3.2,"timeout": 60000}' http://localhost:4567/custom_cat