### PR TITLE
avoid querying mbeannames when not neccessary

### DIFF
--- a/build/build.mk
+++ b/build/build.mk
@@ -1,11 +1,5 @@
-.PHONY : validate-thrift-version
-validate-thrift-version:
-	@printf '\n------------------------------------------------------\n'
-	@printf 'Validating thrift version\n'
-	@build/validate_thrift_version.sh
-
 .PHONY : build
-build: validate-thrift-version
+build:
 	@($(MAVEN_BIN) clean package -DskipTests -P \!deb,\!rpm,\!tarball,\!test,\!tarball)
 
 .PHONY : test
@@ -42,7 +36,7 @@ code-gen-utils:
 						--build-arg THRIFT_VERSION=$(THRIFT_VERSION) ./commons/.)
 
 .PHONY : code-gen
-code-gen: validate-thrift-version
+code-gen:
 	rm -rf src/main/java/org/newrelic/nrjmx/v2/nrprotocol
 	rm -rf gojmx/internal/nrprotocol
 	@($(DOCKER_THRIFT) thrift -r --out src/main/java/ --gen java:generated_annotations=suppress ./commons/nrjmx.thrift)

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -42,7 +42,7 @@ ci/go-test-jdk11: deps go-test-utils
 TRACKED_GEN_DIR=src/main/java/org/newrelic/nrjmx/v2/nrprotocol \
 				gojmx/internal/nrprotocol
 .PHONY : ci/check-gen-code
-ci/check-gen-code: code-gen
+ci/check-gen-code: validate-thrift-version code-gen
 	@echo "Checking the generated code..." ; \
 	if [ `git status --porcelain $(TRACKED_GEN_DIR) | wc -l` -gt 0 ]; then \
 		echo "Code generator produced different code, make sure you pushed the latest changes!"; \
@@ -51,6 +51,11 @@ ci/check-gen-code: code-gen
 	fi ; \
 	echo "Success!"
 
+.PHONY : validate-thrift-version
+validate-thrift-version: deps
+	@printf '\n------------------------------------------------------\n'
+	@printf 'Validating thrift version\n'
+	@($(DOCKER_CMD) build/validate_thrift_version.sh)
 
 .PHONY: ci/docker/publish
 ci/docker/publish: code-gen-utils

--- a/build/validate_thrift_version.sh
+++ b/build/validate_thrift_version.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-JAVA_THRIFT_VERSION=$( mvn dependency:list | grep -P "^\[INFO\]\s+org.apache.thrift:libthrift:jar:" | grep -P -o "\d+\.\d+\.\d+" )
-DOCKER_THRIFT_VERSION=$( grep "THRIFT_VERSION=" commons/Dockerfile | grep -P -o "\d+\.\d+\.\d+" )
+JAVA_THRIFT_VERSION=$( mvn dependency:list | grep -P "^\[INFO\]\s+org.apache.thrift:libthrift:jar:" | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" )
+DOCKER_THRIFT_VERSION=$( grep "THRIFT_VERSION=" commons/Dockerfile | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" )
 cd gojmx
-GO_THRIFT_VERSION=$( go mod graph | grep  -P "^github.com/newrelic/nrjmx/gojmx github.com/apache/thrift" | grep -P -o "\d+\.\d+\.\d+" )
+GO_THRIFT_VERSION=$( go mod graph | grep  -E "^github.com/newrelic/nrjmx/gojmx github.com/apache/thrift" | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" )
 
 if [[ "${JAVA_THRIFT_VERSION}" == "${GO_THRIFT_VERSION}" && "${GO_THRIFT_VERSION}" == "${DOCKER_THRIFT_VERSION}" ]];then
   exit 0

--- a/commons/nrjmx.thrift
+++ b/commons/nrjmx.thrift
@@ -59,5 +59,5 @@ service JMXService {
 
     list<AttributeResponse> getMBeanAttributes(1:string mBeanName, 2:list<string> attributes) throws (1:JMXConnectionError connErr, 2:JMXError jmxErr),
 
-    list<AttributeResponse> queryMBeanAttributes(1:string mBeanNamePattern) throws (1:JMXConnectionError connErr, 2:JMXError jmxErr)
+    list<AttributeResponse> queryMBeanAttributes(1:string mBeanNamePattern, 2:list<string> attributes) throws (1:JMXConnectionError connErr, 2:JMXError jmxErr)
 }

--- a/gojmx/README.md
+++ b/gojmx/README.md
@@ -66,6 +66,8 @@ for _, mBeanName := range mBeanNames {
 }
 
 // Or use QueryMBean call which wraps all the necessary requests to get the values for an MBeanNamePattern.
+// Optionally you can provide atributes to QueryMBeanAttributes in tha same way you provide for GetMBeanAttributes,
+// e.g.: response, err := client.QueryMBeanAttributes("java.lang:type=*", mBeanAttrNames...)
 response, err := client.QueryMBeanAttributes("java.lang:type=*")
 handleError(err)
 for _, attr := range response {

--- a/gojmx/examples/main.go
+++ b/gojmx/examples/main.go
@@ -8,9 +8,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/newrelic/nrjmx/gojmx"
 	"os"
 	"path/filepath"
+
+	"github.com/newrelic/nrjmx/gojmx"
 )
 
 func init() {
@@ -32,7 +33,7 @@ func main() {
 	// Connect to JMX endpoint.
 	client, err := gojmx.NewClient(context.Background()).Open(config)
 	handleError(err)
-	
+
 	defer client.Close()
 
 	// Get the mBean names.
@@ -60,6 +61,8 @@ func main() {
 	}
 
 	// Or use QueryMBean call which wraps all the necessary requests to get the values for an MBeanNamePattern.
+	// Optionally you can provide atributes to QueryMBeanAttributes in tha same way you provide for GetMBeanAttributes,
+	// e.g.: response, err := client.QueryMBeanAttributes("java.lang:type=*", mBeanAttrNames...)
 	response, err := client.QueryMBeanAttributes("java.lang:type=*")
 	handleError(err)
 	for _, attr := range response {

--- a/gojmx/gojmx.go
+++ b/gojmx/gojmx.go
@@ -7,8 +7,9 @@ package gojmx
 
 import (
 	"context"
-	"github.com/apache/thrift/lib/go/thrift"
 	"time"
+
+	"github.com/apache/thrift/lib/go/thrift"
 
 	"github.com/newrelic/nrjmx/gojmx/internal/nrprotocol"
 )
@@ -122,12 +123,12 @@ func (c *Client) GetClientVersion() string {
 // 2. GetMBeanAttributeNames
 // 3. GetMBeanAttributes
 // If an error occur it checks if it's a collection error (it can recover) or a connection error (that blocks all the collection).
-func (c *Client) QueryMBeanAttributes(mBeanNamePattern string) ([]*AttributeResponse, error) {
+func (c *Client) QueryMBeanAttributes(mBeanNamePattern string, mBeanAttrName ...string) ([]*AttributeResponse, error) {
 	if err := c.nrJMXProcess.error(); err != nil {
 		return nil, err
 	}
 
-	result, err := c.jmxService.QueryMBeanAttributes(c.ctx, mBeanNamePattern)
+	result, err := c.jmxService.QueryMBeanAttributes(c.ctx, mBeanNamePattern, mBeanAttrName)
 	return toAttributeResponseList(result), c.handleError(err)
 }
 

--- a/gojmx/gojmx_test.go
+++ b/gojmx/gojmx_test.go
@@ -10,16 +10,17 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/newrelic/nrjmx/gojmx/internal/testutils"
-	gopsutil "github.com/shirou/gopsutil/v3/process"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/newrelic/nrjmx/gojmx/internal/testutils"
+	gopsutil "github.com/shirou/gopsutil/v3/process"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var timeStamp = time.Date(2022, time.January, 1, 01, 23, 45, 0, time.Local).UnixNano() / 1000000

--- a/gojmx/gojmx_test.go
+++ b/gojmx/gojmx_test.go
@@ -229,49 +229,86 @@ func Test_QueryMBean_Success(t *testing.T) {
 	assert.NoError(t, err)
 	defer assertCloseClientNoError(t, client)
 
-	// AND Query returns expected data
-	actualResponse, err := client.QueryMBeanAttributes("test:type=Cat,name=tomas")
-	require.NoError(t, err)
-
-	expectedResponse := []*AttributeResponse{
+	testCases := []struct {
+		name       string
+		query      string
+		attributes []string
+		expected   []*AttributeResponse
+	}{
 		{
-			Name: "test:type=Cat,name=tomas,attr=FloatValue",
+			name:  "With_attributes_specified",
+			query: "test:type=Cat,name=tomas",
+			attributes: []string{
+				"NumberValue",
+				"BoolValue",
+			},
+			expected: []*AttributeResponse{
+				{
+					Name:         "test:type=Cat,name=tomas,attr=NumberValue",
+					ResponseType: ResponseTypeInt,
+					IntValue:     3,
+				},
+				{
+					Name: "test:type=Cat,name=tomas,attr=BoolValue",
 
-			ResponseType: ResponseTypeDouble,
-			DoubleValue:  2.222222,
+					ResponseType: ResponseTypeBool,
+					BoolValue:    true,
+				},
+			},
 		},
 		{
-			Name: "test:type=Cat,name=tomas,attr=NumberValue",
+			name:       "Without_attributes_specified",
+			query:      "test:type=Cat,name=tomas",
+			attributes: nil,
+			expected: []*AttributeResponse{
+				{
+					Name: "test:type=Cat,name=tomas,attr=FloatValue",
 
-			ResponseType: ResponseTypeInt,
-			IntValue:     3,
-		},
-		{
-			Name: "test:type=Cat,name=tomas,attr=BoolValue",
+					ResponseType: ResponseTypeDouble,
+					DoubleValue:  2.222222,
+				},
+				{
+					Name: "test:type=Cat,name=tomas,attr=NumberValue",
 
-			ResponseType: ResponseTypeBool,
-			BoolValue:    true,
-		},
-		{
-			Name: "test:type=Cat,name=tomas,attr=DoubleValue",
+					ResponseType: ResponseTypeInt,
+					IntValue:     3,
+				},
+				{
+					Name: "test:type=Cat,name=tomas,attr=BoolValue",
 
-			ResponseType: ResponseTypeDouble,
-			DoubleValue:  1.2,
-		},
-		{
-			Name: "test:type=Cat,name=tomas,attr=Name",
+					ResponseType: ResponseTypeBool,
+					BoolValue:    true,
+				},
+				{
+					Name: "test:type=Cat,name=tomas,attr=DoubleValue",
 
-			ResponseType: ResponseTypeString,
-			StringValue:  "tomas",
-		},
-		{
-			Name:         "test:type=Cat,name=tomas,attr=DateValue",
-			ResponseType: ResponseTypeErr,
-			StatusMsg:    `can't parse attribute, error: 'found a null value for bean: test:type=Cat,name=tomas,attr=DateValue', cause: 'null', stacktrace: 'null'`,
+					ResponseType: ResponseTypeDouble,
+					DoubleValue:  1.2,
+				},
+				{
+					Name: "test:type=Cat,name=tomas,attr=Name",
+
+					ResponseType: ResponseTypeString,
+					StringValue:  "tomas",
+				},
+				{
+					Name:         "test:type=Cat,name=tomas,attr=DateValue",
+					ResponseType: ResponseTypeErr,
+					StatusMsg:    `can't parse attribute, error: 'found a null value for bean: test:type=Cat,name=tomas,attr=DateValue', cause: 'null', stacktrace: 'null'`,
+				},
+			},
 		},
 	}
 
-	assert.ElementsMatch(t, expectedResponse, actualResponse)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// AND Query returns expected data
+			actualResponse, err := client.QueryMBeanAttributes("test:type=Cat,name=tomas", testCase.attributes...)
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, testCase.expected, actualResponse)
+		})
+	}
 }
 
 func Test_Query_CompositeData(t *testing.T) {

--- a/gojmx/gojmx_test.go
+++ b/gojmx/gojmx_test.go
@@ -237,7 +237,7 @@ func Test_QueryMBean_Success(t *testing.T) {
 	}{
 		{
 			name:  "With_attributes_specified",
-			query: "test:type=Cat,name=tomas",
+			query: "test:type=Cat,name=*",
 			attributes: []string{
 				"NumberValue",
 				"BoolValue",
@@ -303,7 +303,7 @@ func Test_QueryMBean_Success(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			// AND Query returns expected data
-			actualResponse, err := client.QueryMBeanAttributes("test:type=Cat,name=tomas", testCase.attributes...)
+			actualResponse, err := client.QueryMBeanAttributes(testCase.query, testCase.attributes...)
 			require.NoError(t, err)
 
 			assert.ElementsMatch(t, testCase.expected, actualResponse)

--- a/gojmx/internal/nrprotocol/j_m_x_service-remote/j_m_x_service-remote.go
+++ b/gojmx/internal/nrprotocol/j_m_x_service-remote/j_m_x_service-remote.go
@@ -28,7 +28,7 @@ func Usage() {
   fmt.Fprintln(os.Stderr, "   queryMBeanNames(string mBeanNamePattern)")
   fmt.Fprintln(os.Stderr, "   getMBeanAttributeNames(string mBeanName)")
   fmt.Fprintln(os.Stderr, "   getMBeanAttributes(string mBeanName,  attributes)")
-  fmt.Fprintln(os.Stderr, "   queryMBeanAttributes(string mBeanNamePattern)")
+  fmt.Fprintln(os.Stderr, "   queryMBeanAttributes(string mBeanNamePattern,  attributes)")
   fmt.Fprintln(os.Stderr)
   os.Exit(0)
 }
@@ -156,19 +156,19 @@ func main() {
       fmt.Fprintln(os.Stderr, "Connect requires 1 args")
       flag.Usage()
     }
-    arg28 := flag.Arg(1)
-    mbTrans29 := thrift.NewTMemoryBufferLen(len(arg28))
-    defer mbTrans29.Close()
-    _, err30 := mbTrans29.WriteString(arg28)
-    if err30 != nil {
+    arg29 := flag.Arg(1)
+    mbTrans30 := thrift.NewTMemoryBufferLen(len(arg29))
+    defer mbTrans30.Close()
+    _, err31 := mbTrans30.WriteString(arg29)
+    if err31 != nil {
       Usage()
       return
     }
-    factory31 := thrift.NewTJSONProtocolFactory()
-    jsProt32 := factory31.GetProtocol(mbTrans29)
+    factory32 := thrift.NewTJSONProtocolFactory()
+    jsProt33 := factory32.GetProtocol(mbTrans30)
     argvalue0 := nrprotocol.NewJMXConfig()
-    err33 := argvalue0.Read(context.Background(), jsProt32)
-    if err33 != nil {
+    err34 := argvalue0.Read(context.Background(), jsProt33)
+    if err34 != nil {
       Usage()
       return
     }
@@ -219,19 +219,19 @@ func main() {
     }
     argvalue0 := flag.Arg(1)
     value0 := argvalue0
-    arg37 := flag.Arg(2)
-    mbTrans38 := thrift.NewTMemoryBufferLen(len(arg37))
-    defer mbTrans38.Close()
-    _, err39 := mbTrans38.WriteString(arg37)
-    if err39 != nil { 
+    arg38 := flag.Arg(2)
+    mbTrans39 := thrift.NewTMemoryBufferLen(len(arg38))
+    defer mbTrans39.Close()
+    _, err40 := mbTrans39.WriteString(arg38)
+    if err40 != nil { 
       Usage()
       return
     }
-    factory40 := thrift.NewTJSONProtocolFactory()
-    jsProt41 := factory40.GetProtocol(mbTrans38)
+    factory41 := thrift.NewTJSONProtocolFactory()
+    jsProt42 := factory41.GetProtocol(mbTrans39)
     containerStruct1 := nrprotocol.NewJMXServiceGetMBeanAttributesArgs()
-    err42 := containerStruct1.ReadField2(context.Background(), jsProt41)
-    if err42 != nil {
+    err43 := containerStruct1.ReadField2(context.Background(), jsProt42)
+    if err43 != nil {
       Usage()
       return
     }
@@ -241,13 +241,31 @@ func main() {
     fmt.Print("\n")
     break
   case "queryMBeanAttributes":
-    if flag.NArg() - 1 != 1 {
-      fmt.Fprintln(os.Stderr, "QueryMBeanAttributes requires 1 args")
+    if flag.NArg() - 1 != 2 {
+      fmt.Fprintln(os.Stderr, "QueryMBeanAttributes requires 2 args")
       flag.Usage()
     }
     argvalue0 := flag.Arg(1)
     value0 := argvalue0
-    fmt.Print(client.QueryMBeanAttributes(context.Background(), value0))
+    arg45 := flag.Arg(2)
+    mbTrans46 := thrift.NewTMemoryBufferLen(len(arg45))
+    defer mbTrans46.Close()
+    _, err47 := mbTrans46.WriteString(arg45)
+    if err47 != nil { 
+      Usage()
+      return
+    }
+    factory48 := thrift.NewTJSONProtocolFactory()
+    jsProt49 := factory48.GetProtocol(mbTrans46)
+    containerStruct1 := nrprotocol.NewJMXServiceQueryMBeanAttributesArgs()
+    err50 := containerStruct1.ReadField2(context.Background(), jsProt49)
+    if err50 != nil {
+      Usage()
+      return
+    }
+    argvalue1 := containerStruct1.Attributes
+    value1 := argvalue1
+    fmt.Print(client.QueryMBeanAttributes(context.Background(), value0, value1))
     fmt.Print("\n")
     break
   case "":

--- a/gojmx/internal/nrprotocol/nrjmx.go
+++ b/gojmx/internal/nrprotocol/nrjmx.go
@@ -1352,7 +1352,8 @@ type JMXService interface {
   GetMBeanAttributes(ctx context.Context, mBeanName string, attributes []string) (_r []*AttributeResponse, _err error)
   // Parameters:
   //  - MBeanNamePattern
-  QueryMBeanAttributes(ctx context.Context, mBeanNamePattern string) (_r []*AttributeResponse, _err error)
+  //  - Attributes
+  QueryMBeanAttributes(ctx context.Context, mBeanNamePattern string, attributes []string) (_r []*AttributeResponse, _err error)
 }
 
 type JMXServiceClient struct {
@@ -1516,9 +1517,11 @@ func (p *JMXServiceClient) GetMBeanAttributes(ctx context.Context, mBeanName str
 
 // Parameters:
 //  - MBeanNamePattern
-func (p *JMXServiceClient) QueryMBeanAttributes(ctx context.Context, mBeanNamePattern string) (_r []*AttributeResponse, _err error) {
+//  - Attributes
+func (p *JMXServiceClient) QueryMBeanAttributes(ctx context.Context, mBeanNamePattern string, attributes []string) (_r []*AttributeResponse, _err error) {
   var _args18 JMXServiceQueryMBeanAttributesArgs
   _args18.MBeanNamePattern = mBeanNamePattern
+  _args18.Attributes = attributes
   var _result20 JMXServiceQueryMBeanAttributesResult
   var _meta19 thrift.ResponseMeta
   _meta19, _err = p.Client_().Call(ctx, "queryMBeanAttributes", &_args18, &_result20)
@@ -2136,7 +2139,7 @@ func (p *jMXServiceProcessorQueryMBeanAttributes) Process(ctx context.Context, s
 
   result := JMXServiceQueryMBeanAttributesResult{}
   var retval []*AttributeResponse
-  if retval, err2 = p.handler.QueryMBeanAttributes(ctx, args.MBeanNamePattern); err2 != nil {
+  if retval, err2 = p.handler.QueryMBeanAttributes(ctx, args.MBeanNamePattern, args.Attributes); err2 != nil {
     tickerCancel()
   switch v := err2.(type) {
     case *JMXConnectionError:
@@ -3727,8 +3730,10 @@ func (p *JMXServiceGetMBeanAttributesResult) String() string {
 
 // Attributes:
 //  - MBeanNamePattern
+//  - Attributes
 type JMXServiceQueryMBeanAttributesArgs struct {
   MBeanNamePattern string `thrift:"mBeanNamePattern,1" db:"mBeanNamePattern" json:"mBeanNamePattern"`
+  Attributes []string `thrift:"attributes,2" db:"attributes" json:"attributes"`
 }
 
 func NewJMXServiceQueryMBeanAttributesArgs() *JMXServiceQueryMBeanAttributesArgs {
@@ -3738,6 +3743,10 @@ func NewJMXServiceQueryMBeanAttributesArgs() *JMXServiceQueryMBeanAttributesArgs
 
 func (p *JMXServiceQueryMBeanAttributesArgs) GetMBeanNamePattern() string {
   return p.MBeanNamePattern
+}
+
+func (p *JMXServiceQueryMBeanAttributesArgs) GetAttributes() []string {
+  return p.Attributes
 }
 func (p *JMXServiceQueryMBeanAttributesArgs) Read(ctx context.Context, iprot thrift.TProtocol) error {
   if _, err := iprot.ReadStructBegin(ctx); err != nil {
@@ -3755,6 +3764,16 @@ func (p *JMXServiceQueryMBeanAttributesArgs) Read(ctx context.Context, iprot thr
     case 1:
       if fieldTypeId == thrift.STRING {
         if err := p.ReadField1(ctx, iprot); err != nil {
+          return err
+        }
+      } else {
+        if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+          return err
+        }
+      }
+    case 2:
+      if fieldTypeId == thrift.LIST {
+        if err := p.ReadField2(ctx, iprot); err != nil {
           return err
         }
       } else {
@@ -3786,11 +3805,34 @@ func (p *JMXServiceQueryMBeanAttributesArgs)  ReadField1(ctx context.Context, ip
   return nil
 }
 
+func (p *JMXServiceQueryMBeanAttributesArgs)  ReadField2(ctx context.Context, iprot thrift.TProtocol) error {
+  _, size, err := iprot.ReadListBegin(ctx)
+  if err != nil {
+    return thrift.PrependError("error reading list begin: ", err)
+  }
+  tSlice := make([]string, 0, size)
+  p.Attributes =  tSlice
+  for i := 0; i < size; i ++ {
+var _elem27 string
+    if v, err := iprot.ReadString(ctx); err != nil {
+    return thrift.PrependError("error reading field 0: ", err)
+} else {
+    _elem27 = v
+}
+    p.Attributes = append(p.Attributes, _elem27)
+  }
+  if err := iprot.ReadListEnd(ctx); err != nil {
+    return thrift.PrependError("error reading list end: ", err)
+  }
+  return nil
+}
+
 func (p *JMXServiceQueryMBeanAttributesArgs) Write(ctx context.Context, oprot thrift.TProtocol) error {
   if err := oprot.WriteStructBegin(ctx, "queryMBeanAttributes_args"); err != nil {
     return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err) }
   if p != nil {
     if err := p.writeField1(ctx, oprot); err != nil { return err }
+    if err := p.writeField2(ctx, oprot); err != nil { return err }
   }
   if err := oprot.WriteFieldStop(ctx); err != nil {
     return thrift.PrependError("write field stop error: ", err) }
@@ -3806,6 +3848,24 @@ func (p *JMXServiceQueryMBeanAttributesArgs) writeField1(ctx context.Context, op
   return thrift.PrependError(fmt.Sprintf("%T.mBeanNamePattern (1) field write error: ", p), err) }
   if err := oprot.WriteFieldEnd(ctx); err != nil {
     return thrift.PrependError(fmt.Sprintf("%T write field end error 1:mBeanNamePattern: ", p), err) }
+  return err
+}
+
+func (p *JMXServiceQueryMBeanAttributesArgs) writeField2(ctx context.Context, oprot thrift.TProtocol) (err error) {
+  if err := oprot.WriteFieldBegin(ctx, "attributes", thrift.LIST, 2); err != nil {
+    return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:attributes: ", p), err) }
+  if err := oprot.WriteListBegin(ctx, thrift.STRING, len(p.Attributes)); err != nil {
+    return thrift.PrependError("error writing list begin: ", err)
+  }
+  for _, v := range p.Attributes {
+    if err := oprot.WriteString(ctx, string(v)); err != nil {
+    return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err) }
+  }
+  if err := oprot.WriteListEnd(ctx); err != nil {
+    return thrift.PrependError("error writing list end: ", err)
+  }
+  if err := oprot.WriteFieldEnd(ctx); err != nil {
+    return thrift.PrependError(fmt.Sprintf("%T write field end error 2:attributes: ", p), err) }
   return err
 }
 
@@ -3927,11 +3987,11 @@ func (p *JMXServiceQueryMBeanAttributesResult)  ReadField0(ctx context.Context, 
   tSlice := make([]*AttributeResponse, 0, size)
   p.Success =  tSlice
   for i := 0; i < size; i ++ {
-    _elem27 := &AttributeResponse{}
-    if err := _elem27.Read(ctx, iprot); err != nil {
-      return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem27), err)
+    _elem28 := &AttributeResponse{}
+    if err := _elem28.Read(ctx, iprot); err != nil {
+      return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem28), err)
     }
-    p.Success = append(p.Success, _elem27)
+    p.Success = append(p.Success, _elem28)
   }
   if err := iprot.ReadListEnd(ctx); err != nil {
     return thrift.PrependError("error reading list end: ", err)

--- a/src/main/java/org/newrelic/nrjmx/v2/JMXFetcher.java
+++ b/src/main/java/org/newrelic/nrjmx/v2/JMXFetcher.java
@@ -377,7 +377,12 @@ public class JMXFetcher {
     public List<AttributeResponse> queryMBeanAttributes(String mBeanGlobPattern) throws JMXError, JMXConnectionError {
         ObjectName pattern = getObjectName(mBeanGlobPattern);
 
-        Set<ObjectInstance> mBeans = queryMBeans(pattern);
+        Set<ObjectInstance> mBeans;
+        if (mBeanGlobPattern.contains("*")) {
+            mBeans = queryMBeans(pattern);
+        } else {
+            mBeans = new HashSet<>(Arrays.asList(new ObjectInstance(pattern, "")));
+        }
 
         List<AttributeResponse> result = new ArrayList<>();
 

--- a/src/main/java/org/newrelic/nrjmx/v2/JMXFetcher.java
+++ b/src/main/java/org/newrelic/nrjmx/v2/JMXFetcher.java
@@ -242,14 +242,13 @@ public class JMXFetcher {
                     .setMessage("can't get attribute value, provided objectName is Null");
         }
 
-        if (attributes == null) {
-            throw new JMXError()
-                    .setMessage("can't get attribute value, provided attribute name is Null");
-        }
-
         if (output == null) {
             throw new JMXError()
                     .setMessage("can't deserialize attribute value, provided output list is Null");
+        }
+
+        if (attributes == null || attributes.size() == 0) {
+            attributes = getMBeanAttributeNames(objectName);
         }
 
         List<Attribute> attrValues = new ArrayList<>();
@@ -359,9 +358,9 @@ public class JMXFetcher {
      * @throws JMXError           JMX related Exception
      * @throws JMXConnectionError JMX connection related exception
      */
-    public List<AttributeResponse> queryMBeanAttributes(String mBeanGlobPattern, long timeoutMs) throws JMXError, JMXConnectionError {
+    public List<AttributeResponse> queryMBeanAttributes(String mBeanGlobPattern, List<String> attributes, long timeoutMs) throws JMXError, JMXConnectionError {
         return withTimeout(
-                executor.submit(() -> queryMBeanAttributes(mBeanGlobPattern)),
+                executor.submit(() -> queryMBeanAttributes(mBeanGlobPattern, attributes)),
                 timeoutMs
         );
     }
@@ -374,7 +373,7 @@ public class JMXFetcher {
      * @throws JMXError           JMX related Exception
      * @throws JMXConnectionError JMX connection related exception
      */
-    public List<AttributeResponse> queryMBeanAttributes(String mBeanGlobPattern) throws JMXError, JMXConnectionError {
+    public List<AttributeResponse> queryMBeanAttributes(String mBeanGlobPattern, List<String> attributes) throws JMXError, JMXConnectionError {
         ObjectName pattern = getObjectName(mBeanGlobPattern);
 
         Set<ObjectInstance> mBeans;
@@ -391,8 +390,6 @@ public class JMXFetcher {
                 continue;
             }
             ObjectName objectName = mBean.getObjectName();
-
-            List<String> attributes = getMBeanAttributeNames(objectName);
 
             getMBeanAttributes(objectName, attributes, result);
         }

--- a/src/main/java/org/newrelic/nrjmx/v2/JMXServiceHandler.java
+++ b/src/main/java/org/newrelic/nrjmx/v2/JMXServiceHandler.java
@@ -59,8 +59,8 @@ public class JMXServiceHandler implements JMXService.Iface {
     }
 
     @Override
-    public List<AttributeResponse> queryMBeanAttributes(String mBeanNamePattern) throws TException {
-        return jmxFetcher.queryMBeanAttributes(mBeanNamePattern, requestTimeoutMs);
+    public List<AttributeResponse> queryMBeanAttributes(String mBeanNamePattern, List<String> attributes) throws TException {
+        return jmxFetcher.queryMBeanAttributes(mBeanNamePattern, attributes, requestTimeoutMs);
     }
 
     public void addServer(TServer server) {

--- a/src/main/java/org/newrelic/nrjmx/v2/nrprotocol/JMXService.java
+++ b/src/main/java/org/newrelic/nrjmx/v2/nrprotocol/JMXService.java
@@ -23,7 +23,7 @@ public class JMXService {
 
     public java.util.List<AttributeResponse> getMBeanAttributes(java.lang.String mBeanName, java.util.List<java.lang.String> attributes) throws JMXConnectionError, JMXError, org.apache.thrift.TException;
 
-    public java.util.List<AttributeResponse> queryMBeanAttributes(java.lang.String mBeanNamePattern) throws JMXConnectionError, JMXError, org.apache.thrift.TException;
+    public java.util.List<AttributeResponse> queryMBeanAttributes(java.lang.String mBeanNamePattern, java.util.List<java.lang.String> attributes) throws JMXConnectionError, JMXError, org.apache.thrift.TException;
 
   }
 
@@ -41,7 +41,7 @@ public class JMXService {
 
     public void getMBeanAttributes(java.lang.String mBeanName, java.util.List<java.lang.String> attributes, org.apache.thrift.async.AsyncMethodCallback<java.util.List<AttributeResponse>> resultHandler) throws org.apache.thrift.TException;
 
-    public void queryMBeanAttributes(java.lang.String mBeanNamePattern, org.apache.thrift.async.AsyncMethodCallback<java.util.List<AttributeResponse>> resultHandler) throws org.apache.thrift.TException;
+    public void queryMBeanAttributes(java.lang.String mBeanNamePattern, java.util.List<java.lang.String> attributes, org.apache.thrift.async.AsyncMethodCallback<java.util.List<AttributeResponse>> resultHandler) throws org.apache.thrift.TException;
 
   }
 
@@ -226,16 +226,17 @@ public class JMXService {
       throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "getMBeanAttributes failed: unknown result");
     }
 
-    public java.util.List<AttributeResponse> queryMBeanAttributes(java.lang.String mBeanNamePattern) throws JMXConnectionError, JMXError, org.apache.thrift.TException
+    public java.util.List<AttributeResponse> queryMBeanAttributes(java.lang.String mBeanNamePattern, java.util.List<java.lang.String> attributes) throws JMXConnectionError, JMXError, org.apache.thrift.TException
     {
-      send_queryMBeanAttributes(mBeanNamePattern);
+      send_queryMBeanAttributes(mBeanNamePattern, attributes);
       return recv_queryMBeanAttributes();
     }
 
-    public void send_queryMBeanAttributes(java.lang.String mBeanNamePattern) throws org.apache.thrift.TException
+    public void send_queryMBeanAttributes(java.lang.String mBeanNamePattern, java.util.List<java.lang.String> attributes) throws org.apache.thrift.TException
     {
       queryMBeanAttributes_args args = new queryMBeanAttributes_args();
       args.setMBeanNamePattern(mBeanNamePattern);
+      args.setAttributes(attributes);
       sendBase("queryMBeanAttributes", args);
     }
 
@@ -462,24 +463,27 @@ public class JMXService {
       }
     }
 
-    public void queryMBeanAttributes(java.lang.String mBeanNamePattern, org.apache.thrift.async.AsyncMethodCallback<java.util.List<AttributeResponse>> resultHandler) throws org.apache.thrift.TException {
+    public void queryMBeanAttributes(java.lang.String mBeanNamePattern, java.util.List<java.lang.String> attributes, org.apache.thrift.async.AsyncMethodCallback<java.util.List<AttributeResponse>> resultHandler) throws org.apache.thrift.TException {
       checkReady();
-      queryMBeanAttributes_call method_call = new queryMBeanAttributes_call(mBeanNamePattern, resultHandler, this, ___protocolFactory, ___transport);
+      queryMBeanAttributes_call method_call = new queryMBeanAttributes_call(mBeanNamePattern, attributes, resultHandler, this, ___protocolFactory, ___transport);
       this.___currentMethod = method_call;
       ___manager.call(method_call);
     }
 
     public static class queryMBeanAttributes_call extends org.apache.thrift.async.TAsyncMethodCall<java.util.List<AttributeResponse>> {
       private java.lang.String mBeanNamePattern;
-      public queryMBeanAttributes_call(java.lang.String mBeanNamePattern, org.apache.thrift.async.AsyncMethodCallback<java.util.List<AttributeResponse>> resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
+      private java.util.List<java.lang.String> attributes;
+      public queryMBeanAttributes_call(java.lang.String mBeanNamePattern, java.util.List<java.lang.String> attributes, org.apache.thrift.async.AsyncMethodCallback<java.util.List<AttributeResponse>> resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
         super(client, protocolFactory, transport, resultHandler, false);
         this.mBeanNamePattern = mBeanNamePattern;
+        this.attributes = attributes;
       }
 
       public void write_args(org.apache.thrift.protocol.TProtocol prot) throws org.apache.thrift.TException {
         prot.writeMessageBegin(new org.apache.thrift.protocol.TMessage("queryMBeanAttributes", org.apache.thrift.protocol.TMessageType.CALL, 0));
         queryMBeanAttributes_args args = new queryMBeanAttributes_args();
         args.setMBeanNamePattern(mBeanNamePattern);
+        args.setAttributes(attributes);
         args.write(prot);
         prot.writeMessageEnd();
       }
@@ -720,7 +724,7 @@ public class JMXService {
       public queryMBeanAttributes_result getResult(I iface, queryMBeanAttributes_args args) throws org.apache.thrift.TException {
         queryMBeanAttributes_result result = new queryMBeanAttributes_result();
         try {
-          result.success = iface.queryMBeanAttributes(args.mBeanNamePattern);
+          result.success = iface.queryMBeanAttributes(args.mBeanNamePattern, args.attributes);
         } catch (JMXConnectionError connErr) {
           result.connErr = connErr;
         } catch (JMXError jmxErr) {
@@ -1222,7 +1226,7 @@ public class JMXService {
       }
 
       public void start(I iface, queryMBeanAttributes_args args, org.apache.thrift.async.AsyncMethodCallback<java.util.List<AttributeResponse>> resultHandler) throws org.apache.thrift.TException {
-        iface.queryMBeanAttributes(args.mBeanNamePattern,resultHandler);
+        iface.queryMBeanAttributes(args.mBeanNamePattern, args.attributes,resultHandler);
       }
     }
 
@@ -6561,15 +6565,18 @@ public class JMXService {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("queryMBeanAttributes_args");
 
     private static final org.apache.thrift.protocol.TField M_BEAN_NAME_PATTERN_FIELD_DESC = new org.apache.thrift.protocol.TField("mBeanNamePattern", org.apache.thrift.protocol.TType.STRING, (short)1);
+    private static final org.apache.thrift.protocol.TField ATTRIBUTES_FIELD_DESC = new org.apache.thrift.protocol.TField("attributes", org.apache.thrift.protocol.TType.LIST, (short)2);
 
     private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new queryMBeanAttributes_argsStandardSchemeFactory();
     private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new queryMBeanAttributes_argsTupleSchemeFactory();
 
     public @org.apache.thrift.annotation.Nullable java.lang.String mBeanNamePattern; // required
+    public @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> attributes; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-      M_BEAN_NAME_PATTERN((short)1, "mBeanNamePattern");
+      M_BEAN_NAME_PATTERN((short)1, "mBeanNamePattern"),
+      ATTRIBUTES((short)2, "attributes");
 
       private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -6587,6 +6594,8 @@ public class JMXService {
         switch(fieldId) {
           case 1: // M_BEAN_NAME_PATTERN
             return M_BEAN_NAME_PATTERN;
+          case 2: // ATTRIBUTES
+            return ATTRIBUTES;
           default:
             return null;
         }
@@ -6633,6 +6642,9 @@ public class JMXService {
       java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
       tmpMap.put(_Fields.M_BEAN_NAME_PATTERN, new org.apache.thrift.meta_data.FieldMetaData("mBeanNamePattern", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+      tmpMap.put(_Fields.ATTRIBUTES, new org.apache.thrift.meta_data.FieldMetaData("attributes", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
+              new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING))));
       metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(queryMBeanAttributes_args.class, metaDataMap);
     }
@@ -6641,10 +6653,12 @@ public class JMXService {
     }
 
     public queryMBeanAttributes_args(
-      java.lang.String mBeanNamePattern)
+      java.lang.String mBeanNamePattern,
+      java.util.List<java.lang.String> attributes)
     {
       this();
       this.mBeanNamePattern = mBeanNamePattern;
+      this.attributes = attributes;
     }
 
     /**
@@ -6653,6 +6667,10 @@ public class JMXService {
     public queryMBeanAttributes_args(queryMBeanAttributes_args other) {
       if (other.isSetMBeanNamePattern()) {
         this.mBeanNamePattern = other.mBeanNamePattern;
+      }
+      if (other.isSetAttributes()) {
+        java.util.List<java.lang.String> __this__attributes = new java.util.ArrayList<java.lang.String>(other.attributes);
+        this.attributes = __this__attributes;
       }
     }
 
@@ -6663,6 +6681,7 @@ public class JMXService {
     @Override
     public void clear() {
       this.mBeanNamePattern = null;
+      this.attributes = null;
     }
 
     @org.apache.thrift.annotation.Nullable
@@ -6690,6 +6709,47 @@ public class JMXService {
       }
     }
 
+    public int getAttributesSize() {
+      return (this.attributes == null) ? 0 : this.attributes.size();
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    public java.util.Iterator<java.lang.String> getAttributesIterator() {
+      return (this.attributes == null) ? null : this.attributes.iterator();
+    }
+
+    public void addToAttributes(java.lang.String elem) {
+      if (this.attributes == null) {
+        this.attributes = new java.util.ArrayList<java.lang.String>();
+      }
+      this.attributes.add(elem);
+    }
+
+    @org.apache.thrift.annotation.Nullable
+    public java.util.List<java.lang.String> getAttributes() {
+      return this.attributes;
+    }
+
+    public queryMBeanAttributes_args setAttributes(@org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> attributes) {
+      this.attributes = attributes;
+      return this;
+    }
+
+    public void unsetAttributes() {
+      this.attributes = null;
+    }
+
+    /** Returns true if field attributes is set (has been assigned a value) and false otherwise */
+    public boolean isSetAttributes() {
+      return this.attributes != null;
+    }
+
+    public void setAttributesIsSet(boolean value) {
+      if (!value) {
+        this.attributes = null;
+      }
+    }
+
     public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
       switch (field) {
       case M_BEAN_NAME_PATTERN:
@@ -6697,6 +6757,14 @@ public class JMXService {
           unsetMBeanNamePattern();
         } else {
           setMBeanNamePattern((java.lang.String)value);
+        }
+        break;
+
+      case ATTRIBUTES:
+        if (value == null) {
+          unsetAttributes();
+        } else {
+          setAttributes((java.util.List<java.lang.String>)value);
         }
         break;
 
@@ -6708,6 +6776,9 @@ public class JMXService {
       switch (field) {
       case M_BEAN_NAME_PATTERN:
         return getMBeanNamePattern();
+
+      case ATTRIBUTES:
+        return getAttributes();
 
       }
       throw new java.lang.IllegalStateException();
@@ -6722,6 +6793,8 @@ public class JMXService {
       switch (field) {
       case M_BEAN_NAME_PATTERN:
         return isSetMBeanNamePattern();
+      case ATTRIBUTES:
+        return isSetAttributes();
       }
       throw new java.lang.IllegalStateException();
     }
@@ -6748,6 +6821,15 @@ public class JMXService {
           return false;
       }
 
+      boolean this_present_attributes = true && this.isSetAttributes();
+      boolean that_present_attributes = true && that.isSetAttributes();
+      if (this_present_attributes || that_present_attributes) {
+        if (!(this_present_attributes && that_present_attributes))
+          return false;
+        if (!this.attributes.equals(that.attributes))
+          return false;
+      }
+
       return true;
     }
 
@@ -6758,6 +6840,10 @@ public class JMXService {
       hashCode = hashCode * 8191 + ((isSetMBeanNamePattern()) ? 131071 : 524287);
       if (isSetMBeanNamePattern())
         hashCode = hashCode * 8191 + mBeanNamePattern.hashCode();
+
+      hashCode = hashCode * 8191 + ((isSetAttributes()) ? 131071 : 524287);
+      if (isSetAttributes())
+        hashCode = hashCode * 8191 + attributes.hashCode();
 
       return hashCode;
     }
@@ -6776,6 +6862,16 @@ public class JMXService {
       }
       if (isSetMBeanNamePattern()) {
         lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.mBeanNamePattern, other.mBeanNamePattern);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = java.lang.Boolean.compare(isSetAttributes(), other.isSetAttributes());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetAttributes()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.attributes, other.attributes);
         if (lastComparison != 0) {
           return lastComparison;
         }
@@ -6806,6 +6902,14 @@ public class JMXService {
         sb.append("null");
       } else {
         sb.append(this.mBeanNamePattern);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("attributes:");
+      if (this.attributes == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.attributes);
       }
       first = false;
       sb.append(")");
@@ -6859,6 +6963,24 @@ public class JMXService {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
+            case 2: // ATTRIBUTES
+              if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
+                {
+                  org.apache.thrift.protocol.TList _list32 = iprot.readListBegin();
+                  struct.attributes = new java.util.ArrayList<java.lang.String>(_list32.size);
+                  @org.apache.thrift.annotation.Nullable java.lang.String _elem33;
+                  for (int _i34 = 0; _i34 < _list32.size; ++_i34)
+                  {
+                    _elem33 = iprot.readString();
+                    struct.attributes.add(_elem33);
+                  }
+                  iprot.readListEnd();
+                }
+                struct.setAttributesIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -6877,6 +6999,18 @@ public class JMXService {
         if (struct.mBeanNamePattern != null) {
           oprot.writeFieldBegin(M_BEAN_NAME_PATTERN_FIELD_DESC);
           oprot.writeString(struct.mBeanNamePattern);
+          oprot.writeFieldEnd();
+        }
+        if (struct.attributes != null) {
+          oprot.writeFieldBegin(ATTRIBUTES_FIELD_DESC);
+          {
+            oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.attributes.size()));
+            for (java.lang.String _iter35 : struct.attributes)
+            {
+              oprot.writeString(_iter35);
+            }
+            oprot.writeListEnd();
+          }
           oprot.writeFieldEnd();
         }
         oprot.writeFieldStop();
@@ -6900,19 +7034,44 @@ public class JMXService {
         if (struct.isSetMBeanNamePattern()) {
           optionals.set(0);
         }
-        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetAttributes()) {
+          optionals.set(1);
+        }
+        oprot.writeBitSet(optionals, 2);
         if (struct.isSetMBeanNamePattern()) {
           oprot.writeString(struct.mBeanNamePattern);
+        }
+        if (struct.isSetAttributes()) {
+          {
+            oprot.writeI32(struct.attributes.size());
+            for (java.lang.String _iter36 : struct.attributes)
+            {
+              oprot.writeString(_iter36);
+            }
+          }
         }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, queryMBeanAttributes_args struct) throws org.apache.thrift.TException {
         org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-        java.util.BitSet incoming = iprot.readBitSet(1);
+        java.util.BitSet incoming = iprot.readBitSet(2);
         if (incoming.get(0)) {
           struct.mBeanNamePattern = iprot.readString();
           struct.setMBeanNamePatternIsSet(true);
+        }
+        if (incoming.get(1)) {
+          {
+            org.apache.thrift.protocol.TList _list37 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
+            struct.attributes = new java.util.ArrayList<java.lang.String>(_list37.size);
+            @org.apache.thrift.annotation.Nullable java.lang.String _elem38;
+            for (int _i39 = 0; _i39 < _list37.size; ++_i39)
+            {
+              _elem38 = iprot.readString();
+              struct.attributes.add(_elem38);
+            }
+          }
+          struct.setAttributesIsSet(true);
         }
       }
     }
@@ -7404,14 +7563,14 @@ public class JMXService {
             case 0: // SUCCESS
               if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
                 {
-                  org.apache.thrift.protocol.TList _list32 = iprot.readListBegin();
-                  struct.success = new java.util.ArrayList<AttributeResponse>(_list32.size);
-                  @org.apache.thrift.annotation.Nullable AttributeResponse _elem33;
-                  for (int _i34 = 0; _i34 < _list32.size; ++_i34)
+                  org.apache.thrift.protocol.TList _list40 = iprot.readListBegin();
+                  struct.success = new java.util.ArrayList<AttributeResponse>(_list40.size);
+                  @org.apache.thrift.annotation.Nullable AttributeResponse _elem41;
+                  for (int _i42 = 0; _i42 < _list40.size; ++_i42)
                   {
-                    _elem33 = new AttributeResponse();
-                    _elem33.read(iprot);
-                    struct.success.add(_elem33);
+                    _elem41 = new AttributeResponse();
+                    _elem41.read(iprot);
+                    struct.success.add(_elem41);
                   }
                   iprot.readListEnd();
                 }
@@ -7457,9 +7616,9 @@ public class JMXService {
           oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.success.size()));
-            for (AttributeResponse _iter35 : struct.success)
+            for (AttributeResponse _iter43 : struct.success)
             {
-              _iter35.write(oprot);
+              _iter43.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -7506,9 +7665,9 @@ public class JMXService {
         if (struct.isSetSuccess()) {
           {
             oprot.writeI32(struct.success.size());
-            for (AttributeResponse _iter36 : struct.success)
+            for (AttributeResponse _iter44 : struct.success)
             {
-              _iter36.write(oprot);
+              _iter44.write(oprot);
             }
           }
         }
@@ -7526,14 +7685,14 @@ public class JMXService {
         java.util.BitSet incoming = iprot.readBitSet(3);
         if (incoming.get(0)) {
           {
-            org.apache.thrift.protocol.TList _list37 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
-            struct.success = new java.util.ArrayList<AttributeResponse>(_list37.size);
-            @org.apache.thrift.annotation.Nullable AttributeResponse _elem38;
-            for (int _i39 = 0; _i39 < _list37.size; ++_i39)
+            org.apache.thrift.protocol.TList _list45 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRUCT);
+            struct.success = new java.util.ArrayList<AttributeResponse>(_list45.size);
+            @org.apache.thrift.annotation.Nullable AttributeResponse _elem46;
+            for (int _i47 = 0; _i47 < _list45.size; ++_i47)
             {
-              _elem38 = new AttributeResponse();
-              _elem38.read(iprot);
-              struct.success.add(_elem38);
+              _elem46 = new AttributeResponse();
+              _elem46.read(iprot);
+              struct.success.add(_elem46);
             }
           }
           struct.setSuccessIsSet(true);

--- a/test-server/Dockerfile
+++ b/test-server/Dockerfile
@@ -12,10 +12,10 @@ EXPOSE 7199
 COPY --from=builder target/test-server.jar /
 COPY --from=builder truststore /
 COPY --from=builder keystore /
-COPY --from=builder jmxremote.password /usr/local/openjdk-8/lib/management/jmxremote.password
-COPY --from=builder jmxremote.access /usr/local/openjdk-8/lib/management/jmxremote.access
+COPY --from=builder jmxremote.password /usr/local/openjdk-11/conf/management/jmxremote.password
+COPY --from=builder jmxremote.access /usr/local/openjdk-11/conf/management/jmxremote.access
 
-RUN chmod 400 /usr/local/openjdk-8/lib/management/jmxremote.password
+RUN chmod 400 /usr/local/openjdk-11/conf/management/jmxremote.password
 
 ENV JAVA_OPTS -Dcom.sun.management.jmxremote.port=7199 \
       -Dcom.sun.management.jmxremote.authenticate=false \


### PR DESCRIPTION
This PR avoids querying for mbean names when the provided string doesn't contain a wildcard