### PR TITLE
Force returned value to be float64

### DIFF
--- a/gojmx/types.go
+++ b/gojmx/types.go
@@ -6,9 +6,7 @@
 package gojmx
 
 import (
-	"errors"
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -20,8 +18,6 @@ import (
  * We want to keep the generated thrift structures internal to avoid having a heavy API.
  * Here we place things that we want to export.
  */
-
-var ErrNonNumeric = errors.New("non-numeric value")
 
 // JMXConfig keeps the JMX connection settings.
 type JMXConfig nrprotocol.JMXConfig
@@ -75,9 +71,6 @@ func (j *AttributeResponse) GetValueAsFloat() (float64, error) {
 		if err != nil {
 			return 0, err
 		}
-		if isNaNOrInf(parsedValue) {
-			return 0, ErrNonNumeric
-		}
 		return parsedValue, nil
 	case ResponseTypeDouble:
 		return j.DoubleValue, nil
@@ -88,10 +81,6 @@ func (j *AttributeResponse) GetValueAsFloat() (float64, error) {
 	default:
 		panic(fmt.Sprintf("unkown value type: %v", j.ResponseType))
 	}
-}
-
-func isNaNOrInf(f float64) bool {
-	return math.IsNaN(f) || math.IsInf(f, 0) || math.IsInf(f, -1)
 }
 
 // JMXError is reported when a JMX query fails.

--- a/gojmx/types.go
+++ b/gojmx/types.go
@@ -6,7 +6,10 @@
 package gojmx
 
 import (
+	"errors"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"unsafe"
 
@@ -17,6 +20,8 @@ import (
  * We want to keep the generated thrift structures internal to avoid having a heavy API.
  * Here we place things that we want to export.
  */
+
+var ErrNonNumeric = errors.New("non-numeric value")
 
 // JMXConfig keeps the JMX connection settings.
 type JMXConfig nrprotocol.JMXConfig
@@ -55,6 +60,38 @@ func (j *AttributeResponse) GetValue() interface{} {
 	default:
 		panic(fmt.Sprintf("unkown value type: %v", j.ResponseType))
 	}
+}
+
+// GetValueAsFloat casts the value from AttributeResponse to float based on type.
+func (j *AttributeResponse) GetValueAsFloat() (float64, error) {
+	switch (*j).ResponseType {
+	case ResponseTypeBool:
+		if j.BoolValue {
+			return 1, nil
+		}
+		return 0, nil
+	case ResponseTypeString:
+		parsedValue, err := strconv.ParseFloat(fmt.Sprintf("%v", j.StringValue), 64)
+		if err != nil {
+			return 0, err
+		}
+		if isNaNOrInf(parsedValue) {
+			return 0, ErrNonNumeric
+		}
+		return parsedValue, nil
+	case ResponseTypeDouble:
+		return j.DoubleValue, nil
+	case ResponseTypeInt:
+		return float64(j.IntValue), nil
+	case ResponseTypeErr:
+		return 0, nil
+	default:
+		panic(fmt.Sprintf("unkown value type: %v", j.ResponseType))
+	}
+}
+
+func isNaNOrInf(f float64) bool {
+	return math.IsNaN(f) || math.IsInf(f, 0) || math.IsInf(f, -1)
 }
 
 // JMXError is reported when a JMX query fails.

--- a/gojmx/types_test.go
+++ b/gojmx/types_test.go
@@ -70,3 +70,78 @@ func Test_JMXAttribute_GetValue(t *testing.T) {
 		})
 	}
 }
+
+func Test_JMXAttribute_GetValueAsFloat(t *testing.T) {
+	testCases := []struct {
+		name          string
+		jmxAttr       *AttributeResponse
+		errorExpected bool
+		expected      float64
+	}{
+		{
+			name: "Incorrect String Value",
+			jmxAttr: &AttributeResponse{
+				Name:         "test:type=Cat,name=tomas,attr=Name",
+				ResponseType: nrprotocol.ResponseType_STRING,
+				StringValue:  "aaa",
+			},
+			errorExpected: true,
+			expected:      0,
+		},
+		{
+			name: "Double Value",
+			jmxAttr: &AttributeResponse{
+				Name:         "test:type=Cat,name=tomas,attr=FloatValue",
+				ResponseType: nrprotocol.ResponseType_DOUBLE,
+				DoubleValue:  2.222222,
+			},
+			expected: 2.222222,
+		},
+		{
+			name: "Number Value",
+			jmxAttr: &AttributeResponse{
+				Name:         "test:type=Cat,name=tomas,attr=NumberValue",
+				ResponseType: nrprotocol.ResponseType_INT,
+				IntValue:     3,
+			},
+			expected: float64(3),
+		},
+		{
+			name: "Bool Value",
+			jmxAttr: &AttributeResponse{
+				Name:         "test:type=Cat,name=tomas,attr=BoolValue",
+				ResponseType: nrprotocol.ResponseType_BOOL,
+				BoolValue:    true,
+			},
+			expected: 1,
+		},
+		{
+			name: "Double Value",
+			jmxAttr: &AttributeResponse{
+				Name:         "test:type=Cat,name=tomas,attr=DoubleValue",
+				ResponseType: nrprotocol.ResponseType_DOUBLE,
+				DoubleValue:  1.2,
+			},
+			expected: 1.2,
+		},
+		{
+			name: "String Value",
+			jmxAttr: &AttributeResponse{
+				Name:         "test:type=Cat,name=tomas,attr=Name",
+				ResponseType: nrprotocol.ResponseType_STRING,
+				StringValue:  "1.2",
+			},
+			expected: 1.2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			floatVal, err := testCase.jmxAttr.GetValueAsFloat()
+			if testCase.errorExpected {
+				assert.Error(t, err)
+			}
+			assert.Equal(t, testCase.expected, floatVal)
+		})
+	}
+}


### PR DESCRIPTION
## Description

### What are you changing/fixing?

This change adds a method to require the value returned to be casted to float64

### Does your Pull Request introduce breaking changes?

No

### Do the users need to upgrade immediately to the new version?

No

### Do you introduce new dependencies on other libraries?

No

## Checklist: before you submit

- [ x ] apply the labels that best suit the context of your Pull Request.
- [ x ] include unit or integration testing for your changes/additions.

