### PR TITLE
Quadrupled thrift frame size

### DIFF
--- a/src/main/java/org/newrelic/nrjmx/Application.java
+++ b/src/main/java/org/newrelic/nrjmx/Application.java
@@ -99,8 +99,8 @@ public class Application {
         StandardIOServer server = new StandardIOServer(
                 new Args(serverTransport)
                         .processor(processor)
-                        .inputTransportFactory(new TFramedTransport.Factory(8192))
-                        .outputTransportFactory(new TFramedTransport.Factory(8192))
+                        .inputTransportFactory(new TFramedTransport.Factory(32768))
+                        .outputTransportFactory(new TFramedTransport.Factory(32768))
                         .protocolFactory(new TCompactProtocol.Factory()));
 
         handler.addServer(server);


### PR DESCRIPTION
## Description

### What are you changing/fixing?

When attempting to use gojmx to monitor [Trino](https://trino.io) I have stumbled upon the following error:
`nrjmx client error: nrjmx process exited with error: exit status 1: stderr: org.apache.thrift.transport.TTransportException: Frame size (9853) larger than max length (8192)! at org.apache.thrift.transport.layered.TFramedTransport.readFrame(TFramedTransport.java:148)\n  at org.apache.thrift.transport.layered.TFramedTransport.read(TFramedTransport.java:100)\n at org.apache.thrift.transport.TTransport.readAll(TTransport.java:100)\n  at org.apache.thrift.protocol.TCompactProtocol.readByte(TCompactProtocol.java:622)\n    at org.apache.thrift.protocol.TCompactProtocol.readMessageBegin(TCompactProtocol.java:479)\n      at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:27)\n     at org.newrelic.nrjmx.v2.StandardIOServer.listen(StandardIOServer.java:55)\n    at org.newrelic.nrjmx.Application.runV2(Application.java:122)\n   at org.newrelic.nrjmx.Application.main(Application.java:46)\n`

increasing maxLength for TFramedTransport.Factory resolves the issue

### Does your Pull Request introduce breaking changes?

no

### Do the users need to upgrade immediately to the new version?

no

### Do you introduce new dependencies on other libraries?

no



## Checklist: before you submit
[build.log](https://github.com/newrelic/nrjmx/files/15152512/build.log)
- [ ] apply the labels that best suit the context of your Pull Request.
- [ ] include unit or integration testing for your changes/additions.

