### PR TITLE
Nr 366597 automated nrjmx releases

### DIFF
--- a/.github/workflows/automated_release.yaml
+++ b/.github/workflows/automated_release.yaml
@@ -1,0 +1,11 @@
+name: Automated release creation
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 19 * * 3"
+
+jobs:
+  release_management:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_release_automation.yaml@v3
+    secrets: inherit

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -169,6 +169,8 @@ jobs:
           # used for signing package stuff
           gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
           gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}
+          # for testing
+          dest_prefix: "automated_release_testing/"
       
       - name: Test package from Staging repo
         uses: newrelic/integrations-pkg-test-action/linux@v1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -5,7 +5,7 @@ on:
     types:
       - prereleased
     tags:
-      - '*'
+      - 'v*'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -169,6 +169,15 @@ jobs:
           # used for signing package stuff
           gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
           gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}
+      
+      - name: Test package from Staging repo
+        uses: newrelic/integrations-pkg-test-action/linux@v1
+        with:
+          tag: ${{ env.TAG }}
+          integration: 'nrjmx'
+          packageLocation: repo
+          stagingRepo: true
+          upgrade: false
           
       - name: Update title for successful pre-release
         if: ${{ github.event.release.prerelease }}
@@ -179,7 +188,7 @@ jobs:
 
   notify-failure:
     if: ${{ always() && failure() }}
-    needs: [unit-test-linux, test-go-linux-jdk8, test-go-linux-jdk11, check-gen-code, publishing-to-s3]
+    needs: [unit-test-linux, test-go-linux-jdk8, test-go-linux-jdk11, check-gen-code, packaging, packaging-msi, publishing-to-s3]
     runs-on: ubuntu-latest
     steps:
       - name: Notify failure via Slack
@@ -191,7 +200,7 @@ jobs:
 
   update-title-on-failure:
     if: ${{ always() && failure() }}
-    needs: [unit-test-linux, test-go-linux-jdk8, test-go-linux-jdk11, check-gen-code, publishing-to-s3]
+    needs: [unit-test-linux, test-go-linux-jdk8, test-go-linux-jdk11, check-gen-code, packaging, packaging-msi, publishing-to-s3]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -169,8 +169,6 @@ jobs:
           # used for signing package stuff
           gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
           gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}
-          # for testing
-          dest_prefix: "automated_release_testing/"
       
       - name: Test package from Staging repo
         uses: newrelic/integrations-pkg-test-action/linux@v1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
@@ -44,13 +44,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'gojmx/go.mod'
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
@@ -63,13 +63,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'gojmx/go.mod'
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
@@ -97,10 +97,10 @@ jobs:
     needs: [ unit-test-linux, test-go-linux-jdk8, test-go-linux-jdk11, check-gen-code ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get PFX certificate from GH secrets
         shell: bash
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
@@ -169,3 +169,34 @@ jobs:
           # used for signing package stuff
           gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
           gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}
+          
+      - name: Update title for successful pre-release
+        if: ${{ github.event.release.prerelease }}
+        env:
+          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
+        run: |
+          gh release edit ${{ env.TAG }} --title "${{ env.TAG }}"
+
+  notify-failure:
+    if: ${{ always() && failure() }}
+    needs: [unit-test-linux, test-go-linux-jdk8, test-go-linux-jdk11, check-gen-code, publishing-to-s3]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify failure via Slack
+        uses: archive/github-actions-slack@master
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-text: "❌ `${{ github.event.repository.full_name }}`: [prerelease pipeline failed](${{ github.server_url }}/${{ github.event.repository.full_name }}/actions/runs/${{ github.run_id }})."
+
+  update-title-on-failure:
+    if: ${{ always() && failure() }}
+    needs: [unit-test-linux, test-go-linux-jdk8, test-go-linux-jdk11, check-gen-code, publishing-to-s3]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reflect failure in prerelease title
+        env:
+          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
+        run: |
+          gh release edit ${{ env.TAG }} --title "${{ env.TAG }} (pre-release-failure)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,11 @@ env:
 jobs:
   publishing-to-s3:
     name: Publish linux artifacts into s3 production bucket
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
@@ -58,3 +58,22 @@ jobs:
           # used for signing package stuff
           gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
           gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}
+
+      - name: Notify successful release
+        uses: archive/github-actions-slack@master
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-text: "🎉 `${{ github.event.repository.full_name }}`: release promoted successfully! ${{ github.server_url }}/${{ github.event.repository.full_name }}/releases/tag/${{ env.TAG }}"
+
+  notify-failure:
+    if: ${{ always() && failure() }}
+    needs: [publishing-to-s3]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify failure via Slack
+        uses: archive/github-actions-slack@master
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-text: "❌ `${{ github.event.repository.full_name }}`: [release pipeline failed](${{ github.server_url }}/${{ github.event.repository.full_name }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,14 @@ jobs:
           gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
           gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}
 
+      - name: Test package from Prod repo
+        uses: newrelic/integrations-pkg-test-action/linux@v1
+        with:
+          tag: ${{ env.TAG }}
+          integration: 'nrjmx'
+          packageLocation: repo
+          upgrade: false
+
       - name: Notify successful release
         uses: archive/github-actions-slack@master
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
           scan-type: 'fs'
           scan-ref: '.'
           format: 'template'
-          template: '@/contrib/sarif.tpl'
+          template: '@/contrib/sarif'
           output: 'trivy-results-java.sarif'
           severity: 'HIGH,CRITICAL'
           skip-dirs: 'gojmx/'
@@ -37,7 +37,7 @@ jobs:
           scan-type: 'fs'
           scan-ref: 'gojmx/'
           format: 'template'
-          template: '@/contrib/sarif.tpl'
+          template: '@/contrib/sarif'
           output: 'trivy-results-go.sarif'
           severity: 'HIGH,CRITICAL'
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,11 +1,6 @@
 ---
 name: Security Testing
 
-env:
-  SNYK_TOKEN: ${{ secrets.CAOS_SNYK_TOKEN }}
-  DOCKER_HUB_ID: ${{ secrets.OHAI_DOCKER_HUB_ID }}
-  DOCKER_HUB_PASSWORD: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
-
 on:
   push:
     branches:
@@ -17,18 +12,28 @@ on:
 
 jobs:
   scan-deps:
-    name: Run security checks Snyk
-    runs-on: ubuntu-20.04
+    name: Run security checks Trivy
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - uses: actions/checkout@v4
+          
+      - name: Run Trivy vulnerability scanner for Java
+        uses: aquasecurity/trivy-action@master
         with:
-          username: ${{ env.DOCKER_HUB_ID }}
-          password: ${{ env.DOCKER_HUB_PASSWORD }}
-      - name: Scan java code for vulnerabilities with Snyk
-        run: make ci/snyk-test-java
-
-      - name: Scan go code for vulnerabilities with Snyk
-        run: make ci/snyk-test-go
-
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'table'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results-java.sarif'
+          severity: 'HIGH,CRITICAL'
+          skip-dirs: 'gojmx/'
+          
+      - name: Run Trivy vulnerability scanner for Go
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: 'gojmx/'
+          format: 'table'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results-go.sarif'
+          severity: 'HIGH,CRITICAL'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,9 @@ name: Security Testing
 on:
   push:
     branches:
-      - '**'
+      - master
+      - main
+      - renovate/**
   pull_request:
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,10 +5,7 @@ on:
   push:
     branches:
       - '**'
-    tags-ignore:
-      - '**'
-    paths-ignore:
-      - README.md
+  pull_request:
 
 jobs:
   scan-java:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
           scan-type: 'fs'
           scan-ref: '.'
           format: 'template'
-          template: '@/contrib/sarif'
+          template: '@/contrib/sarif.tpl'
           output: 'trivy-results-java.sarif'
           severity: 'HIGH,CRITICAL'
           skip-dirs: 'gojmx/'
@@ -37,7 +37,7 @@ jobs:
           scan-type: 'fs'
           scan-ref: 'gojmx/'
           format: 'template'
-          template: '@/contrib/sarif'
+          template: '@/contrib/sarif.tpl'
           output: 'trivy-results-go.sarif'
           severity: 'HIGH,CRITICAL'
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,8 +11,8 @@ on:
       - README.md
 
 jobs:
-  scan-deps:
-    name: Run security checks Trivy
+  scan-java:
+    name: Scan Java Dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +30,12 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+
+  scan-go:
+    name: Scan Go Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
           
       - name: Run Trivy vulnerability scanner for Go
         uses: aquasecurity/trivy-action@0.29.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,22 +18,28 @@ jobs:
       - uses: actions/checkout@v4
           
       - name: Run Trivy vulnerability scanner for Java
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.29.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
-          format: 'table'
+          format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results-java.sarif'
           severity: 'HIGH,CRITICAL'
           skip-dirs: 'gojmx/'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
           
       - name: Run Trivy vulnerability scanner for Go
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.29.0
         with:
           scan-type: 'fs'
           scan-ref: 'gojmx/'
-          format: 'table'
+          format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results-go.sarif'
           severity: 'HIGH,CRITICAL'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,12 @@ on:
 jobs:
   unit-test-linux:
     name: Linux unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
@@ -31,16 +31,16 @@ jobs:
 
   test-go-linux-jdk8:
     name: Linux unit tests for Go on JDK 8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'gojmx/go.mod'
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
@@ -50,16 +50,16 @@ jobs:
 
   test-go-linux-jdk11:
     name: Linux unit tests for Go on JDK 11
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'gojmx/go.mod'
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
@@ -69,12 +69,12 @@ jobs:
 
   check-gen-code:
     name: Checking generated code
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
@@ -83,14 +83,13 @@ jobs:
 
   test-build:
     name: Test jar compilation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Build noarch
         run: make ci/build
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-### dependencies
+### bugfix
 - Upgraded golang.org/x/net to v0.35.0
 
 ## v1.5.3 - 2020-09-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,34 @@
-# Change Log
+# Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.NEXT
+## Unreleased
 
-## 1.5.3
+### enhancements
+- Moved to automated releases for nrjmx
 
-- Removed `org.yaml` unused bundled dependency. This will reduce the
-  size of the JAR file.
+## v1.5.3 - 2020-09-14
+
+### 🚀 Enhancements
+- Removed `org.yaml` unused bundled dependency. This will reduce the size of the JAR file.
 - Upgraded `jmxterm` to v1.0.2 (fixes a vulnerability in bundled jar)
 
-## 1.5.2 (2019-11-18)
-## Fixed
+## v1.5.2 - 2019-11-18
+
+### 🐞 Bug fixes
 - Install `jmxterm` in `/usr/lib/nrjmx` for deb packages.
 
-## 1.5.1 (2019-11-15)
-## Fixed
+## v1.5.1 - 2019-11-15
+
+### 🐞 Bug fixes
 - Install `jmxterm` in `/usr/bin` for deb packages.
 
-## 1.5.0 (2019-11-15)
+## v1.5.0 - 2019-11-15
+
+### 🚀 Enhancements
 - Build JMXFetcher from full connection URL
 - Set debug log entry on nice log lvl to be shown only for verbose mode
 - Clean up cmd execution log entries
@@ -28,39 +36,45 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Increase test timeout to build on slow boxes
 - Java version file
 - Windows build
-- Include `jmxterm` for troubleshooting queries within mvn packaging for:
-  * tarball
-  * rpm
-  * deb
+- Include `jmxterm` for troubleshooting queries within mvn packaging for tarball, deb, and rpm
 
-## 1.4.1 (2019-10-01)
+## v1.4.1 - 2019-10-01
+
+### 🐞 Bug fixes
 - Fixed issue when parsing float NaN values.
 
-## 1.4.0 (2019-09-18)
-- Upgrade project target to Java 1.8 and allow using a different Java version than 
-the default one by configuring JAVA_HOME or NRIA_JAVA_HOME environment variables.
+## v1.4.0 - 2019-09-18
 
-## 1.3.1 (2019-06-17)
+### 🐞 Bug fixes
+- Upgrade project target to Java 1.8 and allow using a different Java version than the default one by configuring JAVA_HOME or NRIA_JAVA_HOME environment variables.
+
+## v1.3.1 - 2019-06-17
+
+### 🚀 Enhancements
 - (Linux-only) tar.gz packaging as an alternative to the current package managers
 
-## 1.3.0 (2019-06-17)
-## Added
-- Non standard (`jmxrmi`) URI path support via `-uriPath` argument.
-- JBoss remoting v3 support for JBoss Domain-mode as default and Standalone-mode
-  optionally.
+## v1.3.0 - 2019-06-17
 
-## 1.2.1 (2019-06-04)
-## Fixed
+### 🚀 Enhancements
+- Non standard (`jmxrmi`) URI path support via `-uriPath` argument.
+- JBoss remoting v3 support for JBoss Domain-mode as default and Standalone-mode optionally.
+
+## v1.2.1 - 2019-06-04
+
+### 🐞 Bug fixes
 - Fixed SSL connection with keyStore and trustStore 
 
-## 1.1.2 (2019-03-18)
-### Added
+## v1.1.2 - 2019-03-18
+
+### 🚀 Enhancements
 - Added remote argument for JMX remote connections
 
-## 1.0.2 (2018-09-12)
-### Added
+## v1.0.2 - 2018-09-12
+
+### 🚀 Enhancements
 - Catch all exceptions
 
-## 1.0.0 (2017-07-21)
-### Added
+## v1.0.0 - 2017-07-21
+
+### 🚀 Enhancements
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-### enhancements
-- Moved to automated releases for nrjmx
+### dependencies
+- Upgraded golang.org/x/net to v0.35.0
 
 ## v1.5.3 - 2020-09-14
 

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -63,22 +63,3 @@ ci/docker/publish: code-gen-utils
 	@printf 'Publishing docker image\n'
 	@($(DOCKER_BIN) push ohaiops/nrjmx-code-generator:$(THRIFT_VERSION))
 	@($(DOCKER_BIN) push ohaiops/nrjmx-code-generator:latest)
-
-.PHONY: ci/snyk-test-java
-ci/snyk-test-java:
-	@docker run --rm -t \
-			--name "nrjmx-snyk-test-java" \
-			-v $(CURDIR):/src/nrjmx \
-			-w /src/nrjmx \
-			-e SNYK_TOKEN \
-			snyk/snyk:maven-3-jdk-11 snyk test --severity-threshold=high
-
-.PHONY: ci/snyk-test-go
-ci/snyk-test-go:
-	@docker run --rm -t \
-			--name "nrjmx-snyk-test-go" \
-			-v $(CURDIR):/src/nrjmx \
-			-w /src/nrjmx/gojmx \
-			-e SNYK_TOKEN \
-			-e GOFLAGS="-buildvcs=false" \
-			snyk/snyk:golang snyk test --severity-threshold=high

--- a/gojmx/go.mod
+++ b/gojmx/go.mod
@@ -57,8 +57,8 @@ require (
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.32.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
-	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/net v0.34.0 // indirect
+	golang.org/x/crypto v0.33.0 // indirect
+	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250124145028-65684f501c47 // indirect

--- a/gojmx/go.sum
+++ b/gojmx/go.sum
@@ -132,6 +132,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
+golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
+golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -140,6 +142,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
 golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
+golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
+golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Automating the release of `nrjmx`.

There were issues with using the [reusable_on_release.yaml](https://github.com/newrelic/coreint-automation/blob/main/.github/workflows/reusable_on_release.yaml) and [reusable_pre_release.yaml](https://github.com/newrelic/coreint-automation/blob/main/.github/workflows/reusable_pre_release.yaml) from `coreint-automation`

Reusable Pre Release could not be used because
- `test-nix` job which runs unit test on linux does not setup docker credentials which are required for `nrjmx`
- `test-windows` and `test-integration-nix` would be skipped because nrjmx runs these via docker images
- `build-win-packages` could not be reused because the make command as well as the scripts that upload assets to GH work differently
- `publish` could not be reused because of the way appname is set. The prefix `nri-` is always added

Reusable Release could not be reused because
- `publish` could not be reused because of the way appname is set. The prefix `nri-` is always added. 

Modifying these action for the special case of `nrjmx` does not make sense.
Instead of using the reusable workflows this PR focuses on automating the release part.

The automated release action is used to schedule the releases.
The steps like updating the GH prerelease title on successful prerelease, notifying in the case of failed pre release / release, and notifying success in the case of successful release are added.
Fixed the `CHANGELOG` to be acceptable to the automated release action by adding an `Unreleased` section and modifying the format of older entries.

Also Included in the PR:
Updated all the github action versions
Dropped the use of snyk in security testing and moved to trivy like the rest of the integrations.