### PR TITLE
Upgraded runner used for publishing

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -135,7 +135,7 @@ jobs:
 
   publishing-to-s3:
     name: Publish linux artifacts into s3 staging bucket
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     needs: [ packaging, packaging-msi ]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   publishing-to-s3:
     name: Publish linux artifacts into s3 production bucket
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
 
     steps:
       - name: Login to DockerHub


### PR DESCRIPTION
The standard github runner is running out of disk space while publishing packages to S3.
Upgrading to the 4 core linux runner.